### PR TITLE
feat(server): add errormonitor to server and worker tasks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,6 +53,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Server and worker tasks now use `errormonitor` to ensure errors are printed to stderr [#9]
+
 ## [v1.1.0] - 2025-06-07
 
 ### Added
@@ -23,3 +27,4 @@ Initial Public Release
 [v1.0.0]: https://github.com/MichaelHatherly/REPLicant.jl/releases/tag/v1.0.0
 [v1.1.0]: https://github.com/MichaelHatherly/REPLicant.jl/releases/tag/v1.1.0
 [#4]: https://github.com/MichaelHatherly/REPLicant.jl/issues/4
+[#9]: https://github.com/MichaelHatherly/REPLicant.jl/issues/9


### PR DESCRIPTION
Wrap both the server task and worker task with errormonitor to ensure errors during startup or execution are printed to stderr. This prevents silent failures that are difficult to debug.