### PR TITLE
Support IOCapture 1.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ REPLicantReviseExt = "Revise"
 REPLicantTestExt = "Test"
 
 [compat]
-IOCapture = "0.2"
+IOCapture = "0.2, 1"
 Revise = "3"
 Sockets = "1"
 Test = "1"


### PR DESCRIPTION
It is fully backwards compatible with version 0.2.