### PR TITLE
refactor: split _server, dedup client and tests

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -114,6 +114,14 @@ function _resolve_port(port::Integer, project::AbstractString, name::AbstractStr
     throw(_candidates_error(live, "could not pick a server for $target"))
 end
 
+# Consume the value following a flag at `index`, erroring when the flag ends the
+# argument list. Returns the value and the advanced index.
+function _take_value(args, index, flag)
+    index += 1
+    index > length(args) && error("$flag needs a value")
+    return args[index], index
+end
+
 function _parse_client_args(args)
     port = -1
     project = ""
@@ -125,25 +133,18 @@ function _parse_client_args(args)
         if startswith(arg, "--port=")
             port = _parse_port(arg[(length("--port=") + 1):end])
         elseif arg == "--port"
-            index += 1
-            index > length(args) && error("--port needs a value")
-            port = _parse_port(args[index])
+            value, index = _take_value(args, index, "--port")
+            port = _parse_port(value)
         elseif startswith(arg, "--project=")
             project = arg[(length("--project=") + 1):end]
         elseif arg == "--project"
-            index += 1
-            index > length(args) && error("--project needs a value")
-            project = args[index]
+            project, index = _take_value(args, index, "--project")
         elseif startswith(arg, "--name=")
             name = arg[(length("--name=") + 1):end]
         elseif arg == "--name"
-            index += 1
-            index > length(args) && error("--name needs a value")
-            name = args[index]
+            name, index = _take_value(args, index, "--name")
         elseif arg == "-e" || arg == "--eval"
-            index += 1
-            index > length(args) && error("-e needs a value")
-            code = args[index]
+            code, index = _take_value(args, index, "-e")
         else
             error("unrecognized argument: $arg")
         end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -26,12 +26,12 @@ PrecompileTools.@setup_workload begin
                             _read_request(sock)
                             write(sock, "ok")
                             flush(sock)
-                        catch
+                        catch  # dendro-ignore: empty_catch -- throwaway acceptor, per-connection errors are irrelevant to precompilation
                         finally
                             close(sock)
                         end
                     end
-                catch
+                catch  # dendro-ignore: empty_catch -- acceptor loop ends when the listener closes
                 end
                 withenv("REPLICANT_DIR" => dir) do
                     _write_registry_entry(port, dir)
@@ -42,7 +42,7 @@ PrecompileTools.@setup_workload begin
                 end
                 close(listener)
             end
-        catch
+        catch  # dendro-ignore: empty_catch -- guard so a sandbox without loopback never fails precompilation
         end
     end
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -127,12 +127,15 @@ registry entry.
 Base.close(server::Server) = schedule(server.task, InterruptException(); error = true)
 
 function _server(srv::Server)
-    channel = srv.channel
-    mod = srv.mod
-    max_connections = srv.max_connections
-    read_timeout_seconds = srv.read_timeout_seconds
-    verbose = srv.verbose
+    server, port_number, entry_path = _listen_and_register!(srv)
+    # Signal readiness now that the registry entry exists.
+    put!(srv.channel, port_number)
+    return _serve(server, srv, entry_path)
+end
 
+# Bind a listener, register it, and publish its runtime details on the handle.
+# Returns the listener, its port, and its registry entry path.
+function _listen_and_register!(srv::Server)
     # Root the server at the enclosing project. Clients select by this path.
     project = _project_root()
 
@@ -151,93 +154,40 @@ function _server(srv::Server)
     srv.port = port_number
     srv.project = project
     srv.started = started
-    verbose && @info "REPLicant listening" port_number project entry_path
-
-    function shutdown()
-        close(server)
-        # Forget this process's server so a later `label!` can't rewrite a
-        # removed entry.
-        CURRENT_SERVER[] === srv && (CURRENT_SERVER[] = nothing)
-        # Always remove the registry entry to keep the registry clean.
-        return if isfile(entry_path)
-            rm(entry_path; force = true)
-            verbose && @info "Removed registry entry" entry_path
-        end
-    end
+    srv.verbose && @info "REPLicant listening" port_number project entry_path
 
     # Ensure cleanup happens even if the Julia process is terminated.
     atexit() do
         try
-            shutdown()
+            _shutdown_server(server, srv, entry_path)
         catch error
             # Use @debug to avoid noise during forced shutdowns
             @debug "Error during shutdown" error
         end
     end
 
-    put!(channel, port_number)
+    return server, port_number, entry_path
+end
 
+# Run the accept loop with its worker, draining and shutting down on exit.
+function _serve(server, srv::Server, entry_path)
     # Queue accepted requests for the worker. Sized to `max_connections` so the
     # accept loop never blocks on `put!` before the capacity check can reject.
-    request_queue = Channel{ClientRequest}(max_connections)
+    request_queue = Channel{ClientRequest}(srv.max_connections)
 
     # Track active connections to enforce limits
     active_connections = Threads.Atomic{Int}(0)
 
     # Start the worker task that processes requests sequentially
-    worker = errormonitor(
-        Threads.@spawn begin
-            try
-                for request in request_queue
-                    try
-                        _revise(
-                            _handle_client,
-                            request.socket,
-                            request.id,
-                            mod,
-                            read_timeout_seconds,
-                            verbose,
-                        )
-                    finally
-                        # Always decrement counter when done with a connection
-                        Threads.atomic_sub!(active_connections, 1)
-                    end
-                end
-            catch error
-                @error "Error in worker task" error
-            end
-        end
-    )
+    worker = _spawn_worker(request_queue, active_connections, srv)
 
     return try
-        # Simple incrementing ID for request tracking in logs
-        id = 0
-        while true
-            sock = Sockets.accept(server)
-            id += 1
-
-            # Check if at capacity
-            if active_connections[] >= max_connections
-                verbose && @warn "Connection rejected - server at capacity" id current =
-                    active_connections[] max = max_connections
-                # Reject off the accept loop so draining the request never blocks
-                # accepting other connections.
-                @async _reject_at_capacity(sock, id, read_timeout_seconds)
-            else
-                # Accept connection and increment counter
-                Threads.atomic_add!(active_connections, 1)
-                verbose &&
-                    @info "Client connected" id peer = Sockets.getpeername(sock) active =
-                    active_connections[]
-                request = ClientRequest(sock, id)
-                put!(request_queue, request)
-            end
-        end
+        _accept_loop(server, request_queue, active_connections, srv)
     catch error
         # A closed listener (`close`/atexit) surfaces as IOError from `accept`;
         # an explicit shutdown surfaces as InterruptException. Both are normal.
         if isa(error, InterruptException) || isa(error, Base.IOError)
-            verbose && @info "Server shutting down"
+            srv.verbose && @info "Server shutting down"
         else
             @error "Unexpected error in server loop" error
         end
@@ -253,6 +203,74 @@ function _server(srv::Server)
         end
 
         # Ensure cleanup runs even if the server loop fails
-        shutdown()
+        _shutdown_server(server, srv, entry_path)
     end
+end
+
+# Close the listener, drop this process's handle, and remove the registry entry.
+function _shutdown_server(listener, srv, entry_path)
+    close(listener)
+    # Forget this process's server so a later `label!` can't rewrite a
+    # removed entry.
+    CURRENT_SERVER[] === srv && (CURRENT_SERVER[] = nothing)
+    # Always remove the registry entry to keep the registry clean.
+    return if isfile(entry_path)
+        rm(entry_path; force = true)
+        srv.verbose && @info "Removed registry entry" entry_path
+    end
+end
+
+# Worker task: evaluate queued requests sequentially in the persistent module.
+function _spawn_worker(request_queue, active_connections, srv::Server)
+    return errormonitor(
+        Threads.@spawn begin
+            try
+                for request in request_queue
+                    try
+                        _revise(
+                            _handle_client,
+                            request.socket,
+                            request.id,
+                            srv.mod,
+                            srv.read_timeout_seconds,
+                            srv.verbose,
+                        )
+                    finally
+                        # Always decrement counter when done with a connection
+                        Threads.atomic_sub!(active_connections, 1)
+                    end
+                end
+            catch error
+                @error "Error in worker task" error
+            end
+        end
+    )
+end
+
+# Accept connections forever, queuing each for the worker; reject at capacity.
+function _accept_loop(server, request_queue, active_connections, srv::Server)
+    # Simple incrementing ID for request tracking in logs
+    id = 0
+    while true
+        sock = Sockets.accept(server)
+        id += 1
+
+        # Check if at capacity
+        if active_connections[] >= srv.max_connections
+            srv.verbose && @warn "Connection rejected - server at capacity" id current =
+                active_connections[] max = srv.max_connections
+            # Reject off the accept loop so draining the request never blocks
+            # accepting other connections.
+            @async _reject_at_capacity(sock, id, srv.read_timeout_seconds)
+        else
+            # Accept connection and increment counter
+            Threads.atomic_add!(active_connections, 1)
+            srv.verbose &&
+                @info "Client connected" id peer = Sockets.getpeername(sock) active =
+                active_connections[]
+            request = ClientRequest(sock, id)
+            put!(request_queue, request)
+        end
+    end
+    return
 end

--- a/test/server_lifecycle_tests.jl
+++ b/test/server_lifecycle_tests.jl
@@ -124,11 +124,7 @@ end
                 take!(server.channel)
                 @test REPLicant.server() === server
 
-                close(server)
-                try
-                    wait(server.task)
-                catch
-                end
+                Utilities.wait_closed(server)
                 # A stopped server is no longer handed back.
                 @test REPLicant.server() === nothing
             end
@@ -151,7 +147,7 @@ end
     @test contains(sprint(show, MIME("text/plain"), handle[]), "stopped")
 end
 
-@testitem "verbose_logs_lifecycle" tags = [:server_lifecycle] begin
+@testitem "verbose_logs_lifecycle" setup = [Utilities] tags = [:server_lifecycle] begin
     import REPLicant
     import Logging
     import Test
@@ -164,11 +160,7 @@ end
                 Logging.with_logger(logger) do
                     server = REPLicant.Server(; verbose = true)
                     take!(server.channel)
-                    close(server)
-                    try
-                        wait(server.task)
-                    catch
-                    end
+                    Utilities.wait_closed(server)
                 end
                 @test any(r -> contains(r.message, "REPLicant listening"), logger.logs)
             end
@@ -176,7 +168,7 @@ end
     end
 end
 
-@testitem "quiet_by_default" tags = [:server_lifecycle] begin
+@testitem "quiet_by_default" setup = [Utilities] tags = [:server_lifecycle] begin
     import REPLicant
     import Logging
     import Test
@@ -189,11 +181,7 @@ end
                 Logging.with_logger(logger) do
                     server = REPLicant.Server()
                     take!(server.channel)
-                    close(server)
-                    try
-                        wait(server.task)
-                    catch
-                    end
+                    Utilities.wait_closed(server)
                 end
                 @test !any(r -> contains(r.message, "REPLicant listening"), logger.logs)
             end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -28,6 +28,19 @@
         end
     end
 
+    # Close a server and wait for its task to finish, so a test can inspect
+    # post-shutdown state (the registry entry removed, the handle reporting
+    # stopped). `close` schedules an InterruptException into the task that `wait`
+    # re-raises; swallowing it is the expected path.
+    function wait_closed(server)
+        close(server)
+        try
+            wait(server.task)
+        catch  # dendro-ignore: empty_catch -- close schedules the InterruptException wait re-raises
+        end
+        return nothing
+    end
+
     # Start a server in an isolated temporary project with its own registry
     # directory, so tests neither see each other's servers nor touch the real
     # registry.
@@ -54,11 +67,7 @@
                         finally
                             # Wait for shutdown so the registry entry is gone
                             # before the test inspects it.
-                            close(server)
-                            try
-                                wait(server.task)
-                            catch
-                            end
+                            wait_closed(server)
                         end
                     end
                 end
@@ -88,11 +97,7 @@
                             func(start, registry)
                         finally
                             for server in servers
-                                close(server)
-                                try
-                                    wait(server.task)
-                                catch
-                                end
+                                wait_closed(server)
                             end
                         end
                     end


### PR DESCRIPTION
A code-quality scan flagged `_server` as a 130-line function tripping the length, cognitive-complexity, and cyclomatic bands. Split it into `_listen_and_register!`, `_serve`, `_spawn_worker`, `_accept_loop`, and `_shutdown_server`, threading the `Server` handle so each helper reads `mod`/`verbose`/timeouts off it. Behavior is unchanged.

`_parse_client_args` repeated the same consume-value-and-bounds-check three times; `_take_value` replaces it. The server lifecycle tests duplicated the close-and-wait teardown at five sites; `wait_closed` in the test `Utilities` module centralizes it.

Mark the deliberate `empty_catch` blocks in the precompile workload and `wait_closed` with `dendro-ignore`: they swallow expected exceptions no refactor removes.