### PR TITLE
test(jet): add JET analysis to the test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run servers behind a `julia +rpc` channel backed by a central registry: clients discover and route to running servers by project, with several labeled servers per project selectable via `--name` (`REPLicant.label!`) [#19]
 - Add a `replicant` plugin so coding agents can install REPLicant and evaluate Julia through `julia +rpc` [#19]
 - Add `save` and `verbose` keywords to `Server`, plus `REPLicant.server()` to recover a handle saved with `save = true` [#19]
+- Run JET static analysis in the test suite: a `:basic` no-method guard on every supported Julia, plus a sound-mode and optimization-analyzer count ratchet pinned to Julia 1.12 [#21]
 
 ### Changed
 
 - Replace the netcat client and `REPLICANT_PORT` file with a precompiled Julia client and a length-prefixed wire protocol [#19]
 - Depend only on the standard library plus `PrecompileTools`, removing the IOCapture dependency [#19]
+- Tighten types in the accept loop, `label!`, and the client-script path to drop the `Union{Nothing, ...}` and socket instabilities JET flagged [#21]
 
 ### Removed
 
@@ -47,3 +49,4 @@ Initial Public Release
 [#4]: https://github.com/MichaelHatherly/REPLicant.jl/issues/4
 [#9]: https://github.com/MichaelHatherly/REPLicant.jl/issues/9
 [#19]: https://github.com/MichaelHatherly/REPLicant.jl/issues/19
+[#21]: https://github.com/MichaelHatherly/REPLicant.jl/issues/21

--- a/src/channel.jl
+++ b/src/channel.jl
@@ -9,7 +9,9 @@ const RPC_CHANNEL = "rpc"
 # bump. The client runs in the default environment (no `--project`) so REPLicant
 # stays out of the worked-on project's dependencies, like Revise; it lives in the
 # global env, where `using REPLicant` resolves for the client.
-_client_script() = joinpath(pkgdir(@__MODULE__), "bin", "client.jl")
+# `pkgdir` is `nothing` only for a module outside a package; REPLicant always
+# loads as one, so assert `String` to keep the path concretely typed.
+_client_script() = joinpath(pkgdir(@__MODULE__)::String, "bin", "client.jl")
 _julia_exe() = joinpath(Sys.BINDIR, Base.julia_exename())
 
 _quiet(cmd::Cmd) = pipeline(cmd; stdout = devnull, stderr = devnull)

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -129,12 +129,17 @@ function label!(name::AbstractString)
     occursin('\n', name) && error("REPLicant label must not contain a newline.")
     srv = CURRENT_SERVER[]
     isnothing(srv) && error("No REPLicant server is running in this session to label.")
-    conflict = _label_conflict(srv.project, name, srv.port)
+    # A recorded server has bound its port and published its details, so these
+    # fields are set; assert it to drop the `nothing` branch from the union.
+    port = srv.port::Int
+    project = srv.project::String
+    started = srv.started::Dates.DateTime
+    conflict = _label_conflict(project, name, port)
     isnothing(conflict) || error(
-        "A REPLicant server in $(srv.project) is already labeled \"$name\" (port $conflict).",
+        "A REPLicant server in $project is already labeled \"$name\" (port $conflict).",
     )
-    _write_registry_entry(srv.port, srv.project; name, started = srv.started)
+    _write_registry_entry(port, project; name, started)
     srv.name = name
-    @info "Labeled REPLicant server" port = srv.port name
+    @info "Labeled REPLicant server" port name
     return name
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -252,7 +252,9 @@ function _accept_loop(server, request_queue, active_connections, srv::Server)
     # Simple incrementing ID for request tracking in logs
     id = 0
     while true
-        sock = Sockets.accept(server)
+        # `listenany` hands back a `TCPServer`, so `accept` yields a `TCPSocket`;
+        # assert it so the socket stays concretely typed through the accept loop.
+        sock = Sockets.accept(server)::Sockets.TCPSocket
         id += 1
 
         # Check if at capacity

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 REPLicant = "8acbef56-6722-412a-9f59-5674813d37bb"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -6,3 +7,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[compat]
+JET = "0.9, 0.10"

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -1,0 +1,43 @@
+@testitem "JET" tags = [:jet] begin
+    import JET
+
+    # JET loads only a stub on pre-release Julia and errors when called, so skip
+    # the whole analysis there (nightly runs in CI).
+    if isempty(VERSION.prerelease)
+        # Basic static analysis over REPLicant's own module. A no-method branch
+        # or a type-level regression fails here rather than at runtime. Runs on
+        # every stable Julia; JET resolves a version-appropriate release per one.
+        JET.test_package(REPLicant; target_defined_modules = true, mode = :basic)
+
+        # Sound mode and the optimization analyzer flag more, much of it
+        # intentional dynamic dispatch (eval over `Any`, socket IO). Rather than
+        # gate at zero, ratchet: cap the count so it can only fall. Lower a limit
+        # when the count drops; never raise one without a reason. Counts depend on
+        # the Julia and JET versions (JET 0.10 on Julia 1.12), so the ratchet runs
+        # only there.
+        JET_JULIA = v"1.12"
+        SOUND_LIMIT = 312   # JET.report_package(REPLicant; mode = :sound)
+        OPT_LIMIT = 0       # JET.report_opt on _parse_client_args(::Vector{String})
+
+        if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)
+            sound = JET.get_reports(
+                JET.report_package(REPLicant; target_defined_modules = true, mode = :sound),
+            )
+            length(sound) < SOUND_LIMIT &&
+                @info "JET sound below limit; lower SOUND_LIMIT to $(length(sound))"
+            @test length(sound) <= SOUND_LIMIT
+
+            opt = JET.get_reports(
+                JET.report_opt(
+                    Tuple{typeof(REPLicant._parse_client_args), Vector{String}};
+                    target_modules = (REPLicant,),
+                ),
+            )
+            length(opt) < OPT_LIMIT &&
+                @info "JET opt below limit; lower OPT_LIMIT to $(length(opt))"
+            @test length(opt) <= OPT_LIMIT
+        end
+    else
+        @test true skip = true
+    end
+end


### PR DESCRIPTION
Port Dendro's JET setup to REPLicant. A `:basic` no-method guard runs on
every supported Julia; a sound-mode and optimization-analyzer count ratchet
runs only on Julia 1.12, where the counts are reproducible. The opt ratchet
targets `_parse_client_args`, the pure-compute core of the per-call client
path.

JET's Julia compat is tiered, so the test dep uses a range (`0.9, 0.10`)
rather than Dendro's single pin: REPLicant supports Julia 1.10, where only
JET 0.9 resolves.

Reaching a clean `:basic` exposed three type instabilities, now fixed:
`accept` returns a `Union` widened past `TCPSocket`, `Server`'s two-phase
init leaves `port`/`project`/`started` as `Union{Nothing, ...}` at the
`label!` call site, and `pkgdir` returns `Union{Nothing, String}`. Each is
asserted to the type its runtime invariant guarantees.
