### PR TITLE
ci(dendro): gate build on code-quality scan

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,17 +20,19 @@ permissions:
 jobs:
   finalize:
     timeout-minutes: 10
-    needs: [format, test]
+    needs: [format, test, dendro]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - run: |
           echo format: ${{ needs.format.result }}
           echo test: ${{ needs.test.result }}
+          echo dendro: ${{ needs.dendro.result }}
       - run: exit 1
         if: |
           (needs.format.result != 'success') ||
-          (needs.test.result != 'success')
+          (needs.test.result != 'success') ||
+          (needs.dendro.result != 'success')
 
   format:
     timeout-minutes: 20
@@ -97,3 +99,24 @@ jobs:
           verbose: true
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  dendro:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: julia-actions/install-juliaup@05d98a2ef433ca0723a8221e38c4723ea92b0c5f # v3.1.4
+        with:
+          channel: '1.12'
+
+      - uses: julia-actions/cache@2b1bf4d8a138668ac719ea7ca149b53ed8d8401e # v2.0.7
+
+      - name: Instantiate analysis environment
+        run: julia --project=test/dendro -e 'using Pkg; Pkg.instantiate()'
+
+      - name: Run Dendro over REPLicant source
+        run: julia --project=test/dendro test/dendro/dendro.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Gate CI on a Dendro code-quality scan of the package source: a separate Julia 1.12 job fails the build on high-complexity bands or duplicate, stub, and swallowed-error flags [#28]
+
 ## [v2.0.0] - 2026-06-19
 
 ### Added
@@ -53,3 +57,4 @@ Initial Public Release
 [#9]: https://github.com/MichaelHatherly/REPLicant.jl/issues/9
 [#19]: https://github.com/MichaelHatherly/REPLicant.jl/issues/19
 [#21]: https://github.com/MichaelHatherly/REPLicant.jl/issues/21
+[#28]: https://github.com/MichaelHatherly/REPLicant.jl/issues/28

--- a/justfile
+++ b/justfile
@@ -29,6 +29,11 @@ test-tag *tags:
 test-item item:
     julia +rpc -e 'using TestItemRunner; @run_package_tests filter=ti->ti.name == "{{item}}"'
 
+# Run Dendro code-quality analysis over REPLicant's own source (separate Julia 1.12 environment)
+dendro:
+    julia +1.12 --project=test/dendro -e 'using Pkg; Pkg.instantiate()'
+    julia +1.12 --project=test/dendro test/dendro/dendro.jl
+
 changelog:
     julia --project=.ci .ci/changelog.jl
 

--- a/test/dendro/Project.toml
+++ b/test/dendro/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+Dendro = "1795b8db-9815-49e8-b387-5b722b8875ff"
+tree_sitter_julia_jll = "52be201e-a5e9-5cfe-8bf2-2dc4b062171c"
+
+[sources]
+Dendro = {url = "https://github.com/MichaelHatherly/Dendro.jl"}
+
+[compat]
+julia = "1.12"

--- a/test/dendro/dendro.jl
+++ b/test/dendro/dendro.jl
@@ -1,0 +1,56 @@
+# Run Dendro over REPLicant's own source so complexity, duplication, and
+# structural smells cannot regress unnoticed. This lives in a separate environment
+# (test/dendro/Project.toml) and a separate CI job because Dendro is unregistered,
+# sourced from git, and needs Julia 1.12, none of which belong in the main test env.
+#
+# The gate mirrors Dendro's own self-analysis: absolute :high bands plus presence and
+# duplicate flags, none of which depend on the corpus distribution, so the result
+# is deterministic. Percentile flags surface the top of a distribution and are not
+# part of the gate.
+
+using Dendro
+
+# Genuine complexity smells, plus the naturalness and cohesion floors, checked on
+# their absolute :high band only.
+const SMELL_METRICS = (
+    :cyclomatic,
+    :cognitive_complexity,
+    :nesting_depth,
+    :function_length,
+    :boolean_complexity,
+    :unnatural,
+    :low_cohesion,
+)
+
+# Presence-based flags: stubs, swallowed errors, duplicated functions (exact or
+# near), and returns that discard errors from a finally clause.
+const FLAG_METRICS = (
+    :stub_marker,
+    :empty_catch,
+    :empty_body,
+    :duplicate,
+    :near_duplicate,
+    :return_in_finally,
+    :identical_operands,
+    :duplicate_branches,
+)
+
+srcdir = normpath(joinpath(@__DIR__, "..", "..", "src"))
+findings = Dendro.active(Dendro.analyze(srcdir))
+
+gating = filter(findings) do f
+    (f.absolute == :high && f.metric in SMELL_METRICS) || f.metric in FLAG_METRICS
+end
+
+if isempty(gating)
+    println("Dendro analysis clean: $(length(findings)) active finding(s), none gating.")
+else
+    println(stderr, "Dendro analysis: $(length(gating)) gating finding(s) over $srcdir:\n")
+    for f in gating
+        band = f.absolute == :high ? " [high]" : ""
+        for loc in f.locations
+            println(stderr, "  $(f.metric)$band  $(loc.file):$(loc.line)  $(loc.unit)")
+        end
+    end
+    exit(1)
+end


### PR DESCRIPTION
Run Dendro over the package source in a dedicated CI job so complexity,
duplication, and structural smells cannot regress unnoticed.

Dendro is unregistered, sourced from git, and needs Julia 1.12, so it
lives in its own `test/dendro` environment and a separate Linux job
rather than the main test matrix, which still covers 1.10. The gate
mirrors Dendro's own self-analysis: absolute `:high` complexity bands
plus duplicate, stub, and swallowed-error flags, the deterministic
subset that does not depend on corpus distribution. `just dendro` runs
it locally.
