### PR TITLE
ci(tagbot): grant write permissions for tagging

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -4,6 +4,9 @@ on:
     types:
       - created
   workflow_dispatch:
+permissions:
+  contents: write
+  issues: write
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
TagBot ran on every registration but failed to push tags with
`Permission to MichaelHatherly/REPLicant.jl.git denied to
github-actions[bot]` (403). The workflow had no `permissions:` block,
so `GITHUB_TOKEN` inherited the repo read-only default and could push
nothing. Grant `contents: write` to push tags and create releases, and
`issues: write` so the fallback issue opens if tagging fails.

No version was ever tagged. Backfill v1.0.0, v1.1.0, v1.1.1, v2.0.0
with a manual dispatch.
