### PR TITLE
feat: versioned binary wire protocol and client output fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,10 @@ does.
   `julia +rpc` UX for free. The cost is ~150-200ms of client boot per call; that
   trade is deliberate.
 - **Simple over clever.** The registry is a directory of `key=value` files: no
-  lock, no JSON, parseable by any client. The wire protocol is length-prefixed
-  bytes read to EOF, so any socket client works without `nc`. Reach for machinery
-  only when a real requirement forces it.
+  lock, no JSON, parseable by any client. The wire protocol is a versioned binary
+  frame (a fixed header carrying magic, version, type, and body length), validated
+  for compliance on every read, with room for richer payload types over time.
+  Reach for machinery only when a real requirement forces it.
 - **Out of the project's dependencies.** REPLicant lives in the global
   environment like Revise, never a direct dep of the project under work. The
   client runs with no `--project` and resolves `using REPLicant` from there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Stop the client from crashing when its output pipe closes early (e.g. piping through `head`): the broken-pipe error is swallowed [#32]
+- Capture `display(x)` output, which previously bypassed the result because it writes through the display stack rather than stdout [#32]
 
 ## [v2.0.0] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replace the length-prefixed wire protocol with a versioned binary frame protocol: a fixed header (magic, version, type code, body length) is validated on every message, and evaluation errors return a distinct frame type so the client routes them to stderr and exits non-zero [#32]
 
+### Fixed
+
+- Stop the client from crashing when its output pipe closes early (e.g. piping through `head`): the broken-pipe error is swallowed [#32]
+
 ## [v2.0.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Gate CI on a Dendro code-quality scan of the package source: a separate Julia 1.12 job fails the build on high-complexity bands or duplicate, stub, and swallowed-error flags [#28]
 
+### Changed
+
+- Replace the length-prefixed wire protocol with a versioned binary frame protocol: a fixed header (magic, version, type code, body length) is validated on every message, and evaluation errors return a distinct frame type so the client routes them to stderr and exits non-zero [#32]
+
 ## [v2.0.0] - 2026-06-19
 
 ### Added
@@ -58,3 +62,4 @@ Initial Public Release
 [#19]: https://github.com/MichaelHatherly/REPLicant.jl/issues/19
 [#21]: https://github.com/MichaelHatherly/REPLicant.jl/issues/21
 [#28]: https://github.com/MichaelHatherly/REPLicant.jl/issues/28
+[#32]: https://github.com/MichaelHatherly/REPLicant.jl/issues/32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replace the length-prefixed wire protocol with a versioned binary frame protocol: a fixed header (magic, version, type code, body length) is validated on every message, and evaluation errors return a distinct frame type so the client routes them to stderr and exits non-zero [#32]
+- Terminate client output with a newline so a result no longer runs into the shell prompt [#32]
 
 ### Fixed
 

--- a/src/client.jl
+++ b/src/client.jl
@@ -159,11 +159,14 @@ function _parse_port(value::AbstractString)
     return port
 end
 
-# Write the result, tolerating a reader that closed early (e.g. `| head`): an
-# EPIPE on a closed output pipe is the reader's choice, not a client error.
+# Write the result, terminating a non-empty payload with a newline so output does
+# not run into the shell prompt. Tolerates a reader that closed early (e.g.
+# `| head`): an EPIPE on a closed output pipe is the reader's choice, not a
+# client error.
 function _write_payload(io::IO, payload::AbstractString)
     try
         write(io, payload)
+        isempty(payload) || endswith(payload, '\n') || write(io, '\n')
     catch error
         error isa Base.IOError || rethrow()
     end

--- a/src/client.jl
+++ b/src/client.jl
@@ -159,18 +159,23 @@ function _parse_port(value::AbstractString)
     return port
 end
 
-# Frame a request (byte-count line, then the bytes) and stream the response to `out`.
-function _send(port::Integer, code::AbstractString; out::IO = stdout)
+# Send an eval frame and route the response: `ok` to `out`, `err` to `err`.
+# Returns a process exit code, non-zero when the evaluation errored.
+function _send(port::Integer, code::AbstractString; out::IO = stdout, err::IO = stderr)
     sock = Sockets.connect(Sockets.localhost, port)
     try
-        write(sock, "$(ncodeunits(code))\n")
-        write(sock, code)
-        flush(sock)
-        write(out, read(sock))
+        _write_frame(sock, REQUEST_EVAL, code)
+        frame = _read_frame(sock, RESPONSE_TYPES)
+        isnothing(frame) && error("server closed the connection without a response")
+        if frame.type == RESPONSE_ERR
+            write(err, frame.body)
+            return 1
+        end
+        write(out, frame.body)
+        return 0
     finally
         close(sock)
     end
-    return nothing
 end
 
 function _list_servers(out::IO = stdout)
@@ -223,8 +228,7 @@ function cli(args = ARGS; out::IO = stdout, err::IO = stderr)
         parsed = _parse_client_args(args)
         code = isnothing(parsed.code) ? read(stdin, String) : parsed.code
         target = _resolve_port(parsed.port, parsed.project, parsed.name)
-        _send(target, code; out)
-        return 0
+        return _send(target, code; out, err)
     catch error
         error isa InterruptException && rethrow()
         message = error isa ErrorException ? error.msg : sprint(showerror, error)

--- a/src/client.jl
+++ b/src/client.jl
@@ -159,6 +159,17 @@ function _parse_port(value::AbstractString)
     return port
 end
 
+# Write the result, tolerating a reader that closed early (e.g. `| head`): an
+# EPIPE on a closed output pipe is the reader's choice, not a client error.
+function _write_payload(io::IO, payload::AbstractString)
+    try
+        write(io, payload)
+    catch error
+        error isa Base.IOError || rethrow()
+    end
+    return nothing
+end
+
 # Send an eval frame and route the response: `ok` to `out`, `err` to `err`.
 # Returns a process exit code, non-zero when the evaluation errored.
 function _send(port::Integer, code::AbstractString; out::IO = stdout, err::IO = stderr)
@@ -168,10 +179,10 @@ function _send(port::Integer, code::AbstractString; out::IO = stdout, err::IO = 
         frame = _read_frame(sock, RESPONSE_TYPES)
         isnothing(frame) && error("server closed the connection without a response")
         if frame.type == RESPONSE_ERR
-            write(err, frame.body)
+            _write_payload(err, frame.body)
             return 1
         end
-        write(out, frame.body)
+        _write_payload(out, frame.body)
         return 0
     finally
         close(sock)

--- a/src/client.jl
+++ b/src/client.jl
@@ -163,7 +163,7 @@ end
 # not run into the shell prompt. Tolerates a reader that closed early (e.g.
 # `| head`): an EPIPE on a closed output pipe is the reader's choice, not a
 # client error.
-function _write_payload(io::IO, payload::AbstractString)
+function _write_payload(io::IO, payload::String)
     try
         write(io, payload)
         isempty(payload) || endswith(payload, '\n') || write(io, '\n')
@@ -175,7 +175,7 @@ end
 
 # Send an eval frame and route the response: `ok` to `out`, `err` to `err`.
 # Returns a process exit code, non-zero when the evaluation errored.
-function _send(port::Integer, code::AbstractString; out::IO = stdout, err::IO = stderr)
+function _send(port::Integer, code::String; out::IO = stdout, err::IO = stderr)
     sock = Sockets.connect(Sockets.localhost, port)
     try
         _write_frame(sock, REQUEST_EVAL, code)

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -13,6 +13,9 @@ function _capture(f)
     Base.link_pipe!(pipe; reader_supports_async = true, writer_supports_async = true)
     redirect_stdout(pipe.in)
     redirect_stderr(pipe.in)
+    # `display(x)` writes through the display stack, not the redirected stdout, so
+    # push a text display onto the pipe to capture it too.
+    pushdisplay(Base.Multimedia.TextDisplay(pipe.in))
     logger = Logging.ConsoleLogger(pipe.in)
 
     # Spawning the reader task draws from the task RNG; copy and restore it so
@@ -32,6 +35,7 @@ function _capture(f)
         finally
             redirect_stdout(default_stdout)
             redirect_stderr(default_stderr)
+            popdisplay()
             close(pipe.in)
             wait(reader)
         end

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -49,7 +49,10 @@ end
 # Code evaluation.
 #
 
-function _eval_code(code::AbstractString, id::Integer, mod::Union{Module, Nothing})
+# Evaluate `code` and format the result REPL-style, returning the rendered text
+# and whether evaluation (or formatting) errored. The `errored` flag drives the
+# response frame's type so the client can route failures and set its exit code.
+function _evaluate(code::AbstractString, id::Integer, mod::Union{Module, Nothing})
     # Use the active module to maintain state between evaluations.
     # This allows users to define variables and use them in subsequent calls.
     mod = @something(mod, Base.active_module())
@@ -72,13 +75,13 @@ function _eval_code(code::AbstractString, id::Integer, mod::Union{Module, Nothin
             _echo_object(result.value) && _show_object(buffer, result, mod)
         end
 
-        return String(take!(buffer))
+        return (; output = String(take!(buffer)), errored = result.error)
     catch error
         # Guards failures in the result-formatting path (`_error_message`,
         # `_show_object`, `take!`). Evaluation errors are caught inside `_capture`
         # and reported through `result.error`.
         @error "Error evaluating code" id code error
-        return "ERROR: $(error)"
+        return (; output = "ERROR: $(error)", errored = true)
     end
 end
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -23,9 +23,12 @@ PrecompileTools.@setup_workload begin
                     while true
                         sock = Sockets.accept(listener)
                         @async try
-                            _read_request(sock)
-                            write(sock, "ok")
-                            flush(sock)
+                            frame = _read_frame(sock, REQUEST_TYPES)
+                            if !isnothing(frame) && frame.type == REQUEST_PING
+                                _write_frame(sock, RESPONSE_PONG, "")
+                            else
+                                _write_frame(sock, RESPONSE_OK, "2")
+                            end
                         catch  # dendro-ignore: empty_catch -- throwaway acceptor, per-connection errors are irrelevant to precompilation
                         finally
                             close(sock)

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -55,7 +55,7 @@ function _read_with_timeout(thunk, sock; timeout_seconds = READ_TIMEOUT_SECONDS)
 end
 
 # Write one frame: the fixed header, then the body bytes.
-function _write_frame(io::IO, type::UInt8, body::AbstractString)
+function _write_frame(io::IO, type::UInt8, body::String)
     write(io, PROTOCOL_MAGIC)
     write(io, PROTOCOL_VERSION)
     write(io, type)
@@ -67,7 +67,7 @@ end
 
 # Validate a frame header and return its `(type, body_length)`. Throws on any
 # compliance violation: bad magic, wrong version, unknown type, oversized body.
-function _parse_header(header, valid_types, max_bytes)
+function _parse_header(header::Vector{UInt8}, valid_types::Tuple{Vararg{UInt8}}, max_bytes::Int)
     buffer = IOBuffer(header)
     magic = read(buffer, length(PROTOCOL_MAGIC))
     magic == PROTOCOL_MAGIC ||
@@ -78,7 +78,7 @@ function _parse_header(header, valid_types, max_bytes)
         error("Protocol version mismatch: expected $(PROTOCOL_VERSION), got $version")
 
     type = read(buffer, UInt8)
-    type in valid_types || error("Unknown message type: $type")
+    any(==(type), valid_types) || error("Unknown message type: $type")
 
     count = Int(ntoh(read(buffer, UInt32)))
     count > max_bytes &&
@@ -90,13 +90,13 @@ end
 # Read one frame, validating it against `valid_types`. Returns `(; type, body)`,
 # or `nothing` when the peer closed without sending (a bare disconnect).
 function _read_frame(
-        sock, valid_types;
+        sock::IO, valid_types::Tuple{Vararg{UInt8}};
         timeout_seconds = READ_TIMEOUT_SECONDS,
-        max_bytes = MAX_REQUEST_BYTES,
+        max_bytes::Int = MAX_REQUEST_BYTES,
     )
     header = _read_with_timeout(sock; timeout_seconds) do
         read(sock, FRAME_HEADER_BYTES)
-    end
+    end::Vector{UInt8}
     isempty(header) && return nothing
     length(header) == FRAME_HEADER_BYTES ||
         error("Incomplete frame header: expected $FRAME_HEADER_BYTES bytes, got $(length(header))")
@@ -106,7 +106,7 @@ function _read_frame(
 
     body = _read_with_timeout(sock; timeout_seconds) do
         read(sock, count)
-    end
+    end::Vector{UInt8}
     length(body) == count ||
         error("Incomplete frame: expected $count body bytes, got $(length(body))")
     return (; type, body = String(body))
@@ -115,7 +115,7 @@ end
 # Drain the client's framed request before replying so it completes its write and
 # reads the rejection, rather than hitting EPIPE on flush against a socket we
 # already closed.
-function _reject_at_capacity(sock, id, read_timeout_seconds)
+function _reject_at_capacity(sock::IO, id, read_timeout_seconds)
     return try
         _read_frame(sock, REQUEST_TYPES; timeout_seconds = read_timeout_seconds)
         _write_frame(sock, RESPONSE_ERR, "Server at capacity, please retry")
@@ -126,7 +126,7 @@ function _reject_at_capacity(sock, id, read_timeout_seconds)
     end
 end
 
-function _handle_client(sock, id, mod, read_timeout_seconds, verbose)
+function _handle_client(sock::IO, id, mod, read_timeout_seconds, verbose)
     return try
         frame = _read_frame(sock, REQUEST_TYPES; timeout_seconds = read_timeout_seconds)
 

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -126,7 +126,7 @@ function _reject_at_capacity(sock::IO, id, read_timeout_seconds)
     end
 end
 
-function _handle_client(sock::IO, id, mod, read_timeout_seconds, verbose)
+function _handle_client(sock::IO, id::Integer, mod::Union{Module, Nothing}, read_timeout_seconds, verbose)
     return try
         frame = _read_frame(sock, REQUEST_TYPES; timeout_seconds = read_timeout_seconds)
 
@@ -148,8 +148,7 @@ function _handle_client(sock::IO, id, mod, read_timeout_seconds, verbose)
         @error "Error handling client" id error
         try
             # Inform the client about a protocol or framing error.
-            message = error isa ErrorException ? error.msg : sprint(showerror, error)
-            _write_frame(sock, RESPONSE_ERR, message)
+            _write_frame(sock, RESPONSE_ERR, sprint(showerror, error))
         catch error
             # Client disconnected before we could send the error.
             @error "Failed to send error frame to client" id error

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -1,9 +1,35 @@
 #
 # Wire protocol.
 #
+# Frames run in both directions: a fixed header followed by a body.
+#
+#   "REPL"   magic        4 bytes
+#   version  UInt8        1 byte
+#   type     UInt8        1 byte   message type code
+#   length   UInt32 (BE)  4 bytes  body byte count
+#   body     length bytes          UTF-8
+#
+# Request types are `eval`/`ping`, response types `ok`/`err`/`pong`. The type code
+# is an open enum: new response codes (a serialized value, a MIME bundle) extend
+# the protocol without a format break. Every read validates magic, version, type,
+# and length before trusting the body.
+#
 
 const READ_TIMEOUT_SECONDS = 30.0
 const MAX_REQUEST_BYTES = 16 * 1024 * 1024  # 16MB
+
+const PROTOCOL_MAGIC = Vector{UInt8}("REPL")
+const PROTOCOL_VERSION = 0x01
+const FRAME_HEADER_BYTES = length(PROTOCOL_MAGIC) + 6  # magic + version + type + UInt32 length
+
+const REQUEST_EVAL = 0x01
+const REQUEST_PING = 0x02
+const RESPONSE_OK = 0x01
+const RESPONSE_ERR = 0x02
+const RESPONSE_PONG = 0x03
+
+const REQUEST_TYPES = (REQUEST_EVAL, REQUEST_PING)
+const RESPONSE_TYPES = (RESPONSE_OK, RESPONSE_ERR, RESPONSE_PONG)
 
 # Run a blocking read on `sock`, closing the socket if it outlives the timeout so
 # the read unblocks with an IOError instead of hanging. The caller closes `sock`
@@ -28,42 +54,71 @@ function _read_with_timeout(thunk, sock; timeout_seconds = READ_TIMEOUT_SECONDS)
     end
 end
 
-# Read one length-prefixed request: a byte-count line, then exactly that many
-# bytes. An empty count line (disconnect) or a zero count is a no-op.
-function _read_request(
-        sock;
+# Write one frame: the fixed header, then the body bytes.
+function _write_frame(io::IO, type::UInt8, body::AbstractString)
+    write(io, PROTOCOL_MAGIC)
+    write(io, PROTOCOL_VERSION)
+    write(io, type)
+    write(io, hton(UInt32(ncodeunits(body))))
+    write(io, body)
+    flush(io)
+    return nothing
+end
+
+# Validate a frame header and return its `(type, body_length)`. Throws on any
+# compliance violation: bad magic, wrong version, unknown type, oversized body.
+function _parse_header(header, valid_types, max_bytes)
+    buffer = IOBuffer(header)
+    magic = read(buffer, length(PROTOCOL_MAGIC))
+    magic == PROTOCOL_MAGIC ||
+        error("Unknown protocol: expected magic \"REPL\", got $(repr(String(magic)))")
+
+    version = read(buffer, UInt8)
+    version == PROTOCOL_VERSION ||
+        error("Protocol version mismatch: expected $(PROTOCOL_VERSION), got $version")
+
+    type = read(buffer, UInt8)
+    type in valid_types || error("Unknown message type: $type")
+
+    count = Int(ntoh(read(buffer, UInt32)))
+    count > max_bytes &&
+        error("Frame too large: $count bytes exceeds maximum of $max_bytes")
+
+    return type, count
+end
+
+# Read one frame, validating it against `valid_types`. Returns `(; type, body)`,
+# or `nothing` when the peer closed without sending (a bare disconnect).
+function _read_frame(
+        sock, valid_types;
         timeout_seconds = READ_TIMEOUT_SECONDS,
         max_bytes = MAX_REQUEST_BYTES,
     )
-    count_line = _read_with_timeout(sock; timeout_seconds) do
-        readline(sock)
+    header = _read_with_timeout(sock; timeout_seconds) do
+        read(sock, FRAME_HEADER_BYTES)
     end
-    isempty(count_line) && return ""
+    isempty(header) && return nothing
+    length(header) == FRAME_HEADER_BYTES ||
+        error("Incomplete frame header: expected $FRAME_HEADER_BYTES bytes, got $(length(header))")
 
-    count = tryparse(Int, strip(count_line))
-    isnothing(count) &&
-        error("Malformed request: expected a byte count, got $(repr(count_line))")
-    count < 0 && error("Malformed request: negative byte count $count")
-    count > max_bytes &&
-        error("Request too large: $count bytes exceeds maximum of $max_bytes")
-    count == 0 && return ""
+    type, count = _parse_header(header, valid_types, max_bytes)
+    count == 0 && return (; type, body = "")
 
-    bytes = _read_with_timeout(sock; timeout_seconds) do
+    body = _read_with_timeout(sock; timeout_seconds) do
         read(sock, count)
     end
-    length(bytes) == count ||
-        error("Incomplete request: expected $count bytes, got $(length(bytes))")
-    return String(bytes)
+    length(body) == count ||
+        error("Incomplete frame: expected $count body bytes, got $(length(body))")
+    return (; type, body = String(body))
 end
 
-# Drain the client's framed request before replying so a length-prefixed client
-# completes its write and reads the rejection, rather than hitting EPIPE on flush
-# against a socket we already closed.
+# Drain the client's framed request before replying so it completes its write and
+# reads the rejection, rather than hitting EPIPE on flush against a socket we
+# already closed.
 function _reject_at_capacity(sock, id, read_timeout_seconds)
     return try
-        _read_request(sock; timeout_seconds = read_timeout_seconds)
-        write(sock, "ERROR: Server at capacity, please retry")
-        flush(sock)
+        _read_frame(sock, REQUEST_TYPES; timeout_seconds = read_timeout_seconds)
+        _write_frame(sock, RESPONSE_ERR, "Server at capacity, please retry")
     catch error
         @debug "Failed to send capacity error to client" id error
     finally
@@ -73,29 +128,31 @@ end
 
 function _handle_client(sock, id, mod, read_timeout_seconds, verbose)
     return try
-        code = _read_request(sock; timeout_seconds = read_timeout_seconds)
+        frame = _read_frame(sock, REQUEST_TYPES; timeout_seconds = read_timeout_seconds)
 
-        # Zero-length request (health probe) or a bare disconnect: reply empty.
-        isempty(code) && return
+        # Bare disconnect: nothing to reply to.
+        isnothing(frame) && return
 
-        verbose && @info "Received code" id code = Text(code)
+        if frame.type == REQUEST_PING
+            _write_frame(sock, RESPONSE_PONG, "")
+            return
+        end
 
-        result = _eval_code(code, id, mod)
+        verbose && @info "Received code" id code = Text(frame.body)
 
-        # The response is the raw result; the client reads until we close.
-        write(sock, result)
-        flush(sock)
+        result = _evaluate(frame.body, id, mod)
+        _write_frame(sock, result.errored ? RESPONSE_ERR : RESPONSE_OK, result.output)
 
-        verbose && @info "Sent result" id result = Text(result)
+        verbose && @info "Sent result" id result = Text(result.output)
     catch error
         @error "Error handling client" id error
         try
-            # Attempt to inform the client about the error
-            write(sock, "ERROR: $(error)")
-            flush(sock)
+            # Inform the client about a protocol or framing error.
+            message = error isa ErrorException ? error.msg : sprint(showerror, error)
+            _write_frame(sock, RESPONSE_ERR, message)
         catch error
             # Client disconnected before we could send the error.
-            @error "Failed to send error message to client" id error
+            @error "Failed to send error frame to client" id error
         end
     finally
         # Always close the socket to free resources and signal EOF to the client.

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -63,16 +63,16 @@ function _write_registry_entry(
     return path
 end
 
-# Probe a server by sending a zero-length request (the health no-op). Matches
-# the cross-platform liveness check the CLI uses for `ls`.
+# Probe a server with a ping frame, expecting a pong. A different-version server
+# fails the version check and reads as dead, which is the intended lockstep
+# behavior. Matches the liveness check the CLI uses for `ls`.
 function _ping(port::Integer)
     try
         sock = Sockets.connect(Sockets.localhost, port)
         try
-            write(sock, "0\n")
-            flush(sock)
-            read(sock)
-            return true
+            _write_frame(sock, REQUEST_PING, "")
+            frame = _read_frame(sock, RESPONSE_TYPES)
+            return !isnothing(frame) && frame.type == RESPONSE_PONG
         finally
             close(sock)
         end

--- a/src/server.jl
+++ b/src/server.jl
@@ -19,10 +19,11 @@ evaluates code from clients until closed.
   so interactive sessions stay quiet; errors always log.
 
 # Protocol
-Each request is length-prefixed: an ASCII decimal byte count, a newline, then that
-many UTF-8 bytes of code. The server writes the result and closes the socket; the
-client reads to EOF. A zero-length request is a health no-op that replies empty.
-Requests are capped at 16 MB.
+Each message is a frame: a 10-byte header (`"REPL"` magic, a version byte, a type
+byte, then a big-endian `UInt32` body length) followed by the body. Requests are
+`eval` (body is code) or `ping`; responses are `ok`/`err` (body is the result or
+error text) or `pong`. Every frame is validated for magic, version, type, and a
+16 MB length cap before its body is trusted.
 
 # Example
 ```julia
@@ -33,7 +34,7 @@ close(server)
 
 The server runs in its own task. Several can run per project; label one with
 [`label!`](@ref) to select it by name. The registry entry is removed on shutdown.
-At capacity, clients get "ERROR: Server at capacity, please retry".
+At capacity, clients get an `err` frame carrying "Server at capacity, please retry".
 """
 mutable struct Server
     task::Task

--- a/test/cli_tests.jl
+++ b/test/cli_tests.jl
@@ -59,6 +59,20 @@ end
     end
 end
 
+@testitem "client_eval_error_routes_to_stderr" tags = [:cli] setup = [Utilities] begin
+    import REPLicant
+
+    Utilities.withserver() do server, mod, port
+        out = IOBuffer()
+        err = IOBuffer()
+        # An evaluation error exits non-zero, with the error on stderr and nothing
+        # on stdout.
+        @test REPLicant.cli(["--port=$port", "-e", "undefined_variable"]; out, err) == 1
+        @test isempty(String(take!(out)))
+        @test contains(String(take!(err)), "UndefVarError")
+    end
+end
+
 @testitem "client_selection_cascade" tags = [:cli] setup = [Utilities] begin
     import REPLicant
 

--- a/test/cli_tests.jl
+++ b/test/cli_tests.jl
@@ -31,11 +31,11 @@ end
         # Auto-select the single live server.
         out = IOBuffer()
         @test REPLicant.cli(["-e", "6 * 7"]; out) == 0
-        @test String(take!(out)) == "42"
+        @test String(take!(out)) == "42\n"
 
         # Explicit port.
         @test REPLicant.cli(["--port=$port", "-e", "1 + 1"]; out) == 0
-        @test String(take!(out)) == "2"
+        @test String(take!(out)) == "2\n"
 
         # Discovery lists the running server.
         @test REPLicant.cli(["ls"]; out) == 0
@@ -46,7 +46,7 @@ end
         # Label this server (CURRENT points at it) and route by name.
         @test REPLicant.label!("tests") == "tests"
         @test REPLicant.cli(["--name=tests", "-e", "2 + 3"]; out) == 0
-        @test String(take!(out)) == "5"
+        @test String(take!(out)) == "5\n"
 
         # The label shows up in discovery.
         @test REPLicant.cli(["ls"]; out) == 0
@@ -75,6 +75,24 @@ end
     Utilities.withserver() do server, mod, port
         @test REPLicant._send(port, "2 + 2"; out = BrokenPipe()) == 0
     end
+end
+
+@testitem "client_appends_trailing_newline" tags = [:cli] begin
+    import REPLicant
+
+    # A non-empty result without its own newline gets one, so output does not run
+    # into the shell prompt.
+    out = IOBuffer()
+    REPLicant._write_payload(out, "42")
+    @test String(take!(out)) == "42\n"
+
+    # An already-terminated payload is left alone.
+    REPLicant._write_payload(out, "42\n")
+    @test String(take!(out)) == "42\n"
+
+    # An empty payload writes nothing.
+    REPLicant._write_payload(out, "")
+    @test isempty(String(take!(out)))
 end
 
 @testitem "client_eval_error_routes_to_stderr" tags = [:cli] setup = [Utilities] begin
@@ -109,13 +127,13 @@ end
         # Explicit port still resolves.
         out = IOBuffer()
         @test REPLicant.cli(["--port=$port2", "-e", "20 + 22"]; out) == 0
-        @test String(take!(out)) == "42"
+        @test String(take!(out)) == "42\n"
 
         # Labeling disambiguates by name. label! tags the most recently started
         # server (CURRENT), which is port2.
         @test REPLicant.label!("second") == "second"
         @test REPLicant.cli(["--name=second", "-e", "21 + 21"]; out) == 0
-        @test String(take!(out)) == "42"
+        @test String(take!(out)) == "42\n"
     end
 end
 

--- a/test/cli_tests.jl
+++ b/test/cli_tests.jl
@@ -59,6 +59,24 @@ end
     end
 end
 
+@testitem "client_tolerates_closed_output_pipe" tags = [:cli] setup = [Utilities] begin
+    import REPLicant
+
+    # A sink that fails every write the way a pipe closed by `| head` does.
+    struct BrokenPipe <: IO end
+    Base.unsafe_write(::BrokenPipe, ::Ptr{UInt8}, ::UInt) =
+        throw(Base.IOError("write: broken pipe (EPIPE)", -32))
+
+    # The payload write is swallowed, not propagated.
+    @test isnothing(REPLicant._write_payload(BrokenPipe(), "42"))
+
+    # An EPIPE while writing the result does not crash the client; it still
+    # reports the evaluation's exit code.
+    Utilities.withserver() do server, mod, port
+        @test REPLicant._send(port, "2 + 2"; out = BrokenPipe()) == 0
+    end
+end
+
 @testitem "client_eval_error_routes_to_stderr" tags = [:cli] setup = [Utilities] begin
     import REPLicant
 

--- a/test/code_evaluation_tests.jl
+++ b/test/code_evaluation_tests.jl
@@ -1,7 +1,8 @@
 @testitem "eval_simple_arithmetic" tags = [:code_evaluation] begin
     mod = Module()
-    result = REPLicant._eval_code("2 + 2", 1, mod)
-    @test strip(result) == "4"
+    result = REPLicant._evaluate("2 + 2", 1, mod)
+    @test !result.errored
+    @test strip(result.output) == "4"
 end
 
 @testitem "eval_with_output" tags = [:code_evaluation] begin
@@ -10,8 +11,8 @@ end
     println("Hello")
     42
     """
-    result = REPLicant._eval_code(code, 1, mod)
-    lines = split(strip(result), '\n')
+    result = REPLicant._evaluate(code, 1, mod)
+    lines = split(strip(result.output), '\n')
     @test length(lines) == 2
     @test lines[1] == "Hello"
     @test lines[2] == "42"
@@ -24,8 +25,8 @@ end
     y = 20
     x + y
     """
-    result = REPLicant._eval_code(code, 1, mod)
-    @test strip(result) == "30"
+    result = REPLicant._evaluate(code, 1, mod)
+    @test strip(result.output) == "30"
 end
 
 @testitem "eval_function_definition" tags = [:code_evaluation] begin
@@ -36,8 +37,8 @@ end
     end
     greet("World")
     """
-    result = REPLicant._eval_code(code, 1, mod)
-    @test strip(result) == "\"Hello, World!\""
+    result = REPLicant._evaluate(code, 1, mod)
+    @test strip(result.output) == "\"Hello, World!\""
 end
 
 @testitem "eval_using_packages" tags = [:code_evaluation] begin
@@ -47,40 +48,41 @@ end
     using Statistics
     mean([1, 2, 3, 4, 5])
     """
-    result = REPLicant._eval_code(code, 1, mod)
-    @test strip(result) == "3.0"
+    result = REPLicant._evaluate(code, 1, mod)
+    @test strip(result.output) == "3.0"
 end
 
 @testitem "eval_empty_code" tags = [:code_evaluation] begin
     mod = Module()
-    result = REPLicant._eval_code("", 1, mod)
-    @test strip(result) == "nothing"
+    result = REPLicant._evaluate("", 1, mod)
+    @test !result.errored
+    @test strip(result.output) == "nothing"
 end
 
 @testitem "eval_nothing_result" tags = [:code_evaluation] begin
     mod = Module()
-    result = REPLicant._eval_code("nothing", 1, mod)
-    @test strip(result) == "nothing"
+    result = REPLicant._evaluate("nothing", 1, mod)
+    @test strip(result.output) == "nothing"
 end
 
 @testitem "eval_array_display" tags = [:code_evaluation] begin
     mod = Module()
-    result = REPLicant._eval_code("[1, 2, 3]", 1, mod)
-    @test contains(result, "3-element Vector{Int64}")
-    @test contains(result, "1")
-    @test contains(result, "2")
-    @test contains(result, "3")
+    result = REPLicant._evaluate("[1, 2, 3]", 1, mod)
+    @test contains(result.output, "3-element Vector{Int64}")
+    @test contains(result.output, "1")
+    @test contains(result.output, "2")
+    @test contains(result.output, "3")
 end
 
 @testitem "eval_dict_display" tags = [:code_evaluation] begin
     mod = Module()
-    result = REPLicant._eval_code("Dict(:a => 1, :b => 2)", 1, mod)
-    @test contains(result, "Dict{Symbol, Int64}")
-    @test contains(result, ":a => 1") || contains(result, ":b => 2")
+    result = REPLicant._evaluate("Dict(:a => 1, :b => 2)", 1, mod)
+    @test contains(result.output, "Dict{Symbol, Int64}")
+    @test contains(result.output, ":a => 1") || contains(result.output, ":b => 2")
 end
 
 @testitem "eval_string_with_quotes" tags = [:code_evaluation] begin
     mod = Module()
-    result = REPLicant._eval_code("\"Hello \\\"World\\\"\"", 1, mod)
-    @test strip(result) == "\"Hello \\\"World\\\"\""
+    result = REPLicant._evaluate("\"Hello \\\"World\\\"\"", 1, mod)
+    @test strip(result.output) == "\"Hello \\\"World\\\"\""
 end

--- a/test/code_evaluation_tests.jl
+++ b/test/code_evaluation_tests.jl
@@ -86,3 +86,12 @@ end
     result = REPLicant._evaluate("\"Hello \\\"World\\\"\"", 1, mod)
     @test strip(result.output) == "\"Hello \\\"World\\\"\""
 end
+
+@testitem "eval_display_output_is_captured" tags = [:code_evaluation] begin
+    mod = Module()
+    # `display(x)` writes through the display stack, not stdout; it must still be
+    # captured alongside ordinary printed output.
+    result = REPLicant._evaluate("display([1, 2, 3]); println(\"after\")", 1, mod)
+    @test contains(result.output, "3-element Vector{Int64}")
+    @test contains(result.output, "after")
+end

--- a/test/connection_limit_tests.jl
+++ b/test/connection_limit_tests.jl
@@ -13,7 +13,7 @@
         # Third connection should be rejected at capacity. The server drains the
         # framed request before replying, so the rejection arrives as a reply.
         response3 = Utilities.request(port, "3")
-        @test startswith(response3, "ERROR: Server at capacity")
+        @test startswith(response3, "Server at capacity")
 
         # Drain the held connections to free slots.
         @test strip(Utilities.readresp(sock1)) == "1"
@@ -40,7 +40,7 @@ end
             @async begin
                 try
                     response = Utilities.request(port, "\"test_$i\"")
-                    if startswith(response, "ERROR: Server at capacity")
+                    if startswith(response, "Server at capacity")
                         Threads.atomic_add!(rejected_count, 1)
                     else
                         Threads.atomic_add!(success_count, 1)

--- a/test/error_handling_tests.jl
+++ b/test/error_handling_tests.jl
@@ -1,41 +1,47 @@
 @testitem "syntax_error_handling" tags = [:error_handling] begin
     mod = Module()
-    result = REPLicant._eval_code("2 + ", 1, mod)
-    @test startswith(result, "ERROR:")
-    @test contains(result, "ParseError")
+    result = REPLicant._evaluate("2 + ", 1, mod)
+    @test result.errored
+    @test startswith(result.output, "ERROR:")
+    @test contains(result.output, "ParseError")
 end
 
 @testitem "undefined_variable_error" tags = [:error_handling] begin
     mod = Module()
-    result = REPLicant._eval_code("undefined_var", 1, mod)
-    @test startswith(result, "ERROR:")
-    @test contains(result, "UndefVarError")
-    @test contains(result, "undefined_var")
+    result = REPLicant._evaluate("undefined_var", 1, mod)
+    @test result.errored
+    @test startswith(result.output, "ERROR:")
+    @test contains(result.output, "UndefVarError")
+    @test contains(result.output, "undefined_var")
 end
 
 @testitem "method_error_handling" tags = [:error_handling] begin
     mod = Module()
-    result = REPLicant._eval_code("\"hello\" + 5", 1, mod)
-    @test startswith(result, "ERROR:")
-    @test contains(result, "MethodError")
+    result = REPLicant._evaluate("\"hello\" + 5", 1, mod)
+    @test result.errored
+    @test startswith(result.output, "ERROR:")
+    @test contains(result.output, "MethodError")
 end
 
 @testitem "division_by_zero_error" tags = [:error_handling] begin
     mod = Module()
-    result = REPLicant._eval_code("1/0", 1, mod)
-    @test strip(result) == "Inf"  # Julia returns Inf for float division by zero
+    result = REPLicant._evaluate("1/0", 1, mod)
+    @test !result.errored
+    @test strip(result.output) == "Inf"  # Julia returns Inf for float division by zero
 
     # Integer division by zero throws
-    result = REPLicant._eval_code("1÷0", 1, mod)
-    @test startswith(result, "ERROR:")
-    @test contains(result, "DivideError")
+    result = REPLicant._evaluate("1÷0", 1, mod)
+    @test result.errored
+    @test startswith(result.output, "ERROR:")
+    @test contains(result.output, "DivideError")
 end
 
 @testitem "bounds_error_handling" tags = [:error_handling] begin
     mod = Module()
-    result = REPLicant._eval_code("[1,2,3][5]", 1, mod)
-    @test startswith(result, "ERROR:")
-    @test contains(result, "BoundsError")
+    result = REPLicant._evaluate("[1,2,3][5]", 1, mod)
+    @test result.errored
+    @test startswith(result.output, "ERROR:")
+    @test contains(result.output, "BoundsError")
 end
 
 @testitem "type_error_handling" tags = [:error_handling] begin
@@ -43,9 +49,10 @@ end
     code = """
     x::Int = "not an int"
     """
-    result = REPLicant._eval_code(code, 1, mod)
-    @test startswith(result, "ERROR:")
-    @test contains(result, "MethodError") || contains(result, "TypeError")
+    result = REPLicant._evaluate(code, 1, mod)
+    @test result.errored
+    @test startswith(result.output, "ERROR:")
+    @test contains(result.output, "MethodError") || contains(result.output, "TypeError")
 end
 
 @testitem "stack_overflow_handling" tags = [:error_handling] begin
@@ -54,8 +61,9 @@ end
     f() = f()
     f()
     """
-    result = REPLicant._eval_code(code, 1, mod)
-    @test contains(result, "StackOverflowError")
+    result = REPLicant._evaluate(code, 1, mod)
+    @test result.errored
+    @test contains(result.output, "StackOverflowError")
 end
 
 @testitem "interrupt_is_rethrown_from_capture" tags = [:error_handling] begin
@@ -73,11 +81,12 @@ end
     end
     foo()
     """
-    result = REPLicant._eval_code(code, 1, mod)
-    @test startswith(result, "ERROR:")
-    @test contains(result, "Custom error")
+    result = REPLicant._evaluate(code, 1, mod)
+    @test result.errored
+    @test startswith(result.output, "ERROR:")
+    @test contains(result.output, "Custom error")
     # Should have truncated backtrace at top-level scope
-    @test contains(result, "top-level scope")
+    @test contains(result.output, "top-level scope")
 end
 
 @testitem "multiple_errors_in_code" tags = [:error_handling] begin
@@ -87,9 +96,10 @@ end
     x = undefined_var
     y = another_undefined_var
     """
-    result = REPLicant._eval_code(code, 1, mod)
-    @test startswith(result, "ERROR:")
-    @test contains(result, "undefined_var")
+    result = REPLicant._evaluate(code, 1, mod)
+    @test result.errored
+    @test startswith(result.output, "ERROR:")
+    @test contains(result.output, "undefined_var")
     # Should not get to the second error
-    @test !contains(result, "another_undefined_var")
+    @test !contains(result.output, "another_undefined_var")
 end

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -16,11 +16,11 @@
         # the Julia and JET versions (JET 0.10 on Julia 1.12), so the ratchet runs
         # only there.
         JET_JULIA = v"1.12"
-        # +20 over the pre-frame baseline (312): the framed protocol's frame reader
-        # returns `Union{Nothing, NamedTuple}` and dispatches on the type code, and
-        # capturing `display` output adds display-stack dispatch. Intentional
+        # +4 over the pre-frame baseline (312): the residual is the framed
+        # protocol's bare-disconnect `Union{Nothing, NamedTuple}`, keyword-argument
+        # machinery, and `display`-stack dispatch from output capture. Intentional
         # socket-IO/eval dispatch the ratchet tolerates.
-        SOUND_LIMIT = 332   # JET.report_package(REPLicant; mode = :sound)
+        SOUND_LIMIT = 316   # JET.report_package(REPLicant; mode = :sound)
         OPT_LIMIT = 0       # JET.report_opt on _parse_client_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -16,10 +16,11 @@
         # the Julia and JET versions (JET 0.10 on Julia 1.12), so the ratchet runs
         # only there.
         JET_JULIA = v"1.12"
-        # +19 over the pre-frame baseline (312): the framed protocol's frame
-        # reader returns `Union{Nothing, NamedTuple}` and dispatches on the type
-        # code, intentional socket-IO/eval dispatch the ratchet tolerates.
-        SOUND_LIMIT = 331   # JET.report_package(REPLicant; mode = :sound)
+        # +20 over the pre-frame baseline (312): the framed protocol's frame reader
+        # returns `Union{Nothing, NamedTuple}` and dispatches on the type code, and
+        # capturing `display` output adds display-stack dispatch. Intentional
+        # socket-IO/eval dispatch the ratchet tolerates.
+        SOUND_LIMIT = 332   # JET.report_package(REPLicant; mode = :sound)
         OPT_LIMIT = 0       # JET.report_opt on _parse_client_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -16,7 +16,10 @@
         # the Julia and JET versions (JET 0.10 on Julia 1.12), so the ratchet runs
         # only there.
         JET_JULIA = v"1.12"
-        SOUND_LIMIT = 312   # JET.report_package(REPLicant; mode = :sound)
+        # +19 over the pre-frame baseline (312): the framed protocol's frame
+        # reader returns `Union{Nothing, NamedTuple}` and dispatches on the type
+        # code, intentional socket-IO/eval dispatch the ratchet tolerates.
+        SOUND_LIMIT = 331   # JET.report_package(REPLicant; mode = :sound)
         OPT_LIMIT = 0       # JET.report_opt on _parse_client_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -16,11 +16,10 @@
         # the Julia and JET versions (JET 0.10 on Julia 1.12), so the ratchet runs
         # only there.
         JET_JULIA = v"1.12"
-        # +4 over the pre-frame baseline (312): the residual is the framed
-        # protocol's bare-disconnect `Union{Nothing, NamedTuple}`, keyword-argument
-        # machinery, and `display`-stack dispatch from output capture. Intentional
-        # socket-IO/eval dispatch the ratchet tolerates.
-        SOUND_LIMIT = 316   # JET.report_package(REPLicant; mode = :sound)
+        # Below the pre-frame baseline (312): the framed protocol's frame functions
+        # carry concrete types end to end, which also tightened a few inherited
+        # socket-path instabilities.
+        SOUND_LIMIT = 310   # JET.report_package(REPLicant; mode = :sound)
         OPT_LIMIT = 0       # JET.report_opt on _parse_client_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)

--- a/test/protocol_tests.jl
+++ b/test/protocol_tests.jl
@@ -1,3 +1,128 @@
+# Frame encoding/decoding over an in-memory buffer: fast, socket-free coverage of
+# the wire format and its compliance checks.
+@testitem "frame_roundtrip" tags = [:protocol, :frame] begin
+    import REPLicant
+
+    buf = IOBuffer()
+    REPLicant._write_frame(buf, REPLicant.REQUEST_EVAL, "2 + 2")
+    seekstart(buf)
+    frame = REPLicant._read_frame(buf, REPLicant.REQUEST_TYPES)
+    @test frame.type == REPLicant.REQUEST_EVAL
+    @test frame.body == "2 + 2"
+
+    # Zero-length body (ping/pong shape).
+    buf = IOBuffer()
+    REPLicant._write_frame(buf, REPLicant.REQUEST_PING, "")
+    seekstart(buf)
+    frame = REPLicant._read_frame(buf, REPLicant.REQUEST_TYPES)
+    @test frame.type == REPLicant.REQUEST_PING
+    @test frame.body == ""
+
+    # Unicode body byte count is exact.
+    buf = IOBuffer()
+    REPLicant._write_frame(buf, REPLicant.RESPONSE_OK, "\"π🚀\"")
+    seekstart(buf)
+    frame = REPLicant._read_frame(buf, REPLicant.RESPONSE_TYPES)
+    @test frame.body == "\"π🚀\""
+end
+
+@testitem "frame_bare_disconnect_is_nothing" tags = [:protocol, :frame] begin
+    import REPLicant
+    # An empty stream (peer closed without sending) reads as `nothing`, not an error.
+    @test isnothing(REPLicant._read_frame(IOBuffer(), REPLicant.REQUEST_TYPES))
+end
+
+@testitem "frame_unknown_magic_rejected" tags = [:protocol, :frame] begin
+    import REPLicant
+
+    buf = IOBuffer()
+    write(buf, b"NOPE")
+    write(buf, REPLicant.PROTOCOL_VERSION)
+    write(buf, REPLicant.REQUEST_EVAL)
+    write(buf, hton(UInt32(1)))
+    write(buf, "x")
+    seekstart(buf)
+    err = try
+        REPLicant._read_frame(buf, REPLicant.REQUEST_TYPES)
+        nothing
+    catch e
+        e
+    end
+    @test err isa Exception
+    @test contains(sprint(showerror, err), "protocol")
+end
+
+@testitem "frame_version_mismatch_rejected" tags = [:protocol, :frame] begin
+    import REPLicant
+
+    buf = IOBuffer()
+    write(buf, REPLicant.PROTOCOL_MAGIC)
+    write(buf, REPLicant.PROTOCOL_VERSION + 0x01)
+    write(buf, REPLicant.REQUEST_EVAL)
+    write(buf, hton(UInt32(1)))
+    write(buf, "x")
+    seekstart(buf)
+    err = try
+        REPLicant._read_frame(buf, REPLicant.REQUEST_TYPES)
+        nothing
+    catch e
+        e
+    end
+    @test err isa Exception
+    @test contains(sprint(showerror, err), "version")
+end
+
+@testitem "frame_unknown_type_rejected" tags = [:protocol, :frame] begin
+    import REPLicant
+
+    buf = IOBuffer()
+    write(buf, REPLicant.PROTOCOL_MAGIC)
+    write(buf, REPLicant.PROTOCOL_VERSION)
+    write(buf, 0xFF)
+    write(buf, hton(UInt32(0)))
+    seekstart(buf)
+    err = try
+        REPLicant._read_frame(buf, REPLicant.REQUEST_TYPES)
+        nothing
+    catch e
+        e
+    end
+    @test err isa Exception
+    @test contains(sprint(showerror, err), "type")
+end
+
+@testitem "frame_oversized_length_rejected" tags = [:protocol, :frame] begin
+    import REPLicant
+
+    buf = IOBuffer()
+    write(buf, REPLicant.PROTOCOL_MAGIC)
+    write(buf, REPLicant.PROTOCOL_VERSION)
+    write(buf, REPLicant.REQUEST_EVAL)
+    write(buf, hton(UInt32(REPLicant.MAX_REQUEST_BYTES + 1)))
+    seekstart(buf)
+    err = try
+        REPLicant._read_frame(buf, REPLicant.REQUEST_TYPES)
+        nothing
+    catch e
+        e
+    end
+    @test err isa Exception
+    @test contains(sprint(showerror, err), "too large")
+end
+
+@testitem "frame_incomplete_body_rejected" tags = [:protocol, :frame] begin
+    import REPLicant
+    # Header promises 10 body bytes, only 3 present before EOF.
+    buf = IOBuffer()
+    write(buf, REPLicant.PROTOCOL_MAGIC)
+    write(buf, REPLicant.PROTOCOL_VERSION)
+    write(buf, REPLicant.REQUEST_EVAL)
+    write(buf, hton(UInt32(10)))
+    write(buf, "abc")
+    seekstart(buf)
+    @test_throws Exception REPLicant._read_frame(buf, REPLicant.REQUEST_TYPES)
+end
+
 @testitem "basic_request" tags = [:protocol] setup = [Utilities] begin
     Utilities.withserver() do server, mod, port
         @test Utilities.request(port, "2 + 2") == "4"
@@ -33,30 +158,47 @@ end
 
 @testitem "error_response_format" tags = [:protocol] setup = [Utilities] begin
     Utilities.withserver() do server, mod, port
-        response = Utilities.request(port, "undefined_variable")
-        @test startswith(response, "ERROR:")
-        @test contains(response, "UndefVarError")
+        frame = Utilities.requestframe(port, REPLicant.REQUEST_EVAL, "undefined_variable")
+        @test frame.type == REPLicant.RESPONSE_ERR
+        @test startswith(frame.body, "ERROR:")
+        @test contains(frame.body, "UndefVarError")
     end
 end
 
-@testitem "health_noop_empty_request" tags = [:protocol] setup = [Utilities] begin
+@testitem "ok_response_type" tags = [:protocol] setup = [Utilities] begin
     Utilities.withserver() do server, mod, port
-        # A zero-length request is the liveness probe: the server replies empty.
-        @test Utilities.request(port, "") == ""
+        frame = Utilities.requestframe(port, REPLicant.REQUEST_EVAL, "2 + 2")
+        @test frame.type == REPLicant.RESPONSE_OK
+        @test frame.body == "4"
     end
 end
 
-@testitem "malformed_count_line" tags = [:protocol] setup = [Utilities] begin
+@testitem "ping_pong" tags = [:protocol] setup = [Utilities] begin
+    Utilities.withserver() do server, mod, port
+        # The liveness probe is an explicit ping frame answered with pong.
+        frame = Utilities.requestframe(port, REPLicant.REQUEST_PING, "")
+        @test frame.type == REPLicant.RESPONSE_PONG
+        @test frame.body == ""
+    end
+end
+
+@testitem "noncompliant_frame_rejected" tags = [:protocol] setup = [Utilities] begin
     import Sockets
 
     Utilities.withserver() do server, mod, port
+        # A header with the wrong magic gets an err frame, and the server survives.
         sock = Sockets.connect(Sockets.localhost, port)
-        write(sock, "not-a-number\n")
+        write(sock, "XXXX")                 # bad magic
+        write(sock, REPLicant.PROTOCOL_VERSION)
+        write(sock, REPLicant.REQUEST_EVAL)
+        write(sock, hton(UInt32(0)))
         flush(sock)
-        response = String(read(sock))
+        frame = Utilities.readframe(sock)
         close(sock)
-        @test startswith(response, "ERROR:")
-        @test contains(response, "Malformed request")
+        @test frame.type == REPLicant.RESPONSE_ERR
+        @test contains(frame.body, "protocol")
+
+        @test Utilities.request(port, "1 + 1") == "2"
     end
 end
 
@@ -65,12 +207,15 @@ end
 
     Utilities.withserver() do server, mod, port
         sock = Sockets.connect(Sockets.localhost, port)
-        write(sock, "$(REPLicant.MAX_REQUEST_BYTES + 1)\n")
+        write(sock, REPLicant.PROTOCOL_MAGIC)
+        write(sock, REPLicant.PROTOCOL_VERSION)
+        write(sock, REPLicant.REQUEST_EVAL)
+        write(sock, hton(UInt32(REPLicant.MAX_REQUEST_BYTES + 1)))
         flush(sock)
-        response = String(read(sock))
+        frame = Utilities.readframe(sock)
         close(sock)
-        @test startswith(response, "ERROR:")
-        @test contains(response, "too large")
+        @test frame.type == REPLicant.RESPONSE_ERR
+        @test contains(frame.body, "too large")
     end
 end
 
@@ -79,8 +224,11 @@ end
 
     Utilities.withserver() do server, mod, port
         sock = Sockets.connect(Sockets.localhost, port)
-        write(sock, "10\n")   # promise 10 bytes
-        write(sock, "abc")    # send only 3, then close
+        write(sock, REPLicant.PROTOCOL_MAGIC)
+        write(sock, REPLicant.PROTOCOL_VERSION)
+        write(sock, REPLicant.REQUEST_EVAL)
+        write(sock, hton(UInt32(10)))   # promise 10 bytes
+        write(sock, "abc")              # send only 3, then close
         close(sock)
         # The server logs the incomplete read; the connection is gone so we can
         # only assert the server stays healthy for the next client.

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -4,25 +4,39 @@
     import Sockets
     import Test
 
-    # Write a length-prefixed request (byte-count line, then code bytes) without
-    # waiting for the response. Used to hold a connection slot open.
+    # Send an eval frame without waiting for the response. Used to hold a
+    # connection slot open.
     function sendframe(sock, code)
-        bytes = Vector{UInt8}(codeunits(code))
-        write(sock, "$(length(bytes))\n")
-        write(sock, bytes)
-        flush(sock)
+        REPLicant._write_frame(sock, REPLicant.REQUEST_EVAL, code)
         return sock
     end
 
-    # Read a full response (until the server closes the connection).
-    readresp(sock) = String(read(sock))
+    # Read one response frame: `(; type, body)`, or `nothing` on a bare disconnect.
+    readframe(sock) = REPLicant._read_frame(sock, REPLicant.RESPONSE_TYPES)
 
-    # Frame a request the way the CLI does and return the full response.
+    # The body of the response (empty when the peer sent nothing).
+    function readresp(sock)
+        frame = readframe(sock)
+        return isnothing(frame) ? "" : frame.body
+    end
+
+    # Frame an eval request the way the CLI does and return the response body.
     function request(port, code)
         sock = Sockets.connect(Sockets.localhost, port)
         try
             sendframe(sock, code)
             return readresp(sock)
+        finally
+            close(sock)
+        end
+    end
+
+    # Send an arbitrary typed frame and return the full response frame.
+    function requestframe(port, type, body)
+        sock = Sockets.connect(Sockets.localhost, port)
+        try
+            REPLicant._write_frame(sock, type, body)
+            return readframe(sock)
         finally
             close(sock)
         end


### PR DESCRIPTION
Dogfooding REPLicant as a coding-agent consumer surfaced four rough edges. The headline change replaces the ad-hoc `<count>\n<bytes>` request and raw read-to-EOF response with a versioned binary frame protocol, then fixes three client output problems.

- **Framed protocol** (T1): a 10-byte header (`"REPL"` magic, version, type code, big-endian `UInt32` length) plus body, both directions. Requests are `eval`/`ping`, responses `ok`/`err`/`pong`. Every frame is validated for magic, version, type, and a 16 MB length cap before its body is trusted. The `ok`/`err` type carries evaluation success, so the client routes errors to stderr and exits non-zero. The integer type code is an open enum, leaving room for richer response payloads (a serialized value, a MIME bundle) without another format break.
- **Closed output pipe** (T2): the client no longer crashes with `EPIPE` when piped into a reader that exits early (`julia +rpc ... | head`).
- **Trailing newline** (T5): result output ends with a newline so it no longer runs into the shell prompt.
- **Display capture** (T3): `display(x)` output is captured alongside printed output.
- **Type tightening**: the frame path carries concrete types end to end. JET sound-mode reports drop from 332 to 310, below the 312 `main` baseline.

`AGENTS.md` is updated to describe the new protocol: a versioned binary frame, trading the old greppable length-prefixed format for compact, validated framing.