### PR TITLE
feat(evaluation): add help mode, suppress nothing echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a help mode: code beginning with `?` returns documentation, like the REPL. With REPL loaded (the interactive server) it is the full `helpmode`, covering operators, keywords, macros, and `?"text"` apropos search; a headless server falls back to `@doc` for bindings, operators, and macros. `??name` gives extended help [#33]
 - Gate CI on a Dendro code-quality scan of the package source: a separate Julia 1.12 job fails the build on high-complexity bands or duplicate, stub, and swallowed-error flags [#28]
 
 ### Changed
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stop the client from crashing when its output pipe closes early (e.g. piping through `head`): the broken-pipe error is swallowed [#32]
 - Capture `display(x)` output, which previously bypassed the result because it writes through the display stack rather than stdout [#32]
+- Suppress the `nothing` echo: a `nothing` result now prints nothing, matching the REPL, so `display(x)` no longer leaves a trailing `nothing` [#33]
 
 ## [v2.0.0] - 2026-06-19
 
@@ -69,3 +71,4 @@ Initial Public Release
 [#21]: https://github.com/MichaelHatherly/REPLicant.jl/issues/21
 [#28]: https://github.com/MichaelHatherly/REPLicant.jl/issues/28
 [#32]: https://github.com/MichaelHatherly/REPLicant.jl/issues/32
+[#33]: https://github.com/MichaelHatherly/REPLicant.jl/issues/33

--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,12 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [weakdeps]
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [extensions]
+REPLicantREPLExt = "REPL"
 REPLicantReviseExt = "Revise"
 REPLicantTestExt = "Test"
 
@@ -22,6 +24,7 @@ REPLicantTestExt = "Test"
 Dates = "1"
 Logging = "1"
 PrecompileTools = "1"
+REPL = "1"
 Random = "1"
 Revise = "3"
 Sockets = "1"

--- a/ext/REPLicantREPLExt.jl
+++ b/ext/REPLicantREPLExt.jl
@@ -1,0 +1,20 @@
+module REPLicantREPLExt
+
+import REPLicant
+import REPL
+
+# Override the base __help fallback when REPL is available, rendering the full
+# help mode: operators, keywords, macros, and apropos `?"text"` search.
+function REPLicant.__help(::Nothing, query::AbstractString, mod::Module)
+    return try
+        io = IOBuffer()
+        # helpmode prints a `search: ...` line to `io` and returns a docs object
+        # (nothing for apropos `?"text"`, which prints its hits to `io`).
+        docs = Core.eval(mod, REPL.helpmode(io, query, mod))
+        (; output = String(take!(io)) * REPLicant._render_md(docs, mod), errored = false)
+    catch error
+        (; output = "ERROR: $(error)", errored = true)
+    end
+end
+
+end

--- a/plugins/replicant/skills/replicant/references/evaluate.md
+++ b/plugins/replicant/skills/replicant/references/evaluate.md
@@ -30,6 +30,20 @@ avoids the question.
 Output is REPL-style: captured stdout and stderr first, then the value, or a
 scrubbed error with backtrace.
 
+## Help mode
+
+A leading `?` returns documentation, like the REPL's help mode. Use `?name` for
+brief help, `??name` for extended:
+
+```bash
+julia +rpc -e '?println'
+julia +rpc -e '?+'
+```
+
+With REPL loaded (the interactive server, the default) this is the full help mode:
+operators, keywords, macros, and `?"text"` apropos search. A headless server falls
+back to `@doc`, covering bindings, operators, and macros.
+
 ## Session state
 
 The server evaluates into a persistent `Main`, so bindings survive across calls:

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -60,6 +60,10 @@ function _evaluate(code::AbstractString, id::Integer, mod::Union{Module, Nothing
     # Use the active module to maintain state between evaluations.
     # This allows users to define variables and use them in subsequent calls.
     mod = @something(mod, Base.active_module())
+    if _is_help_query(code)
+        query = chop(lstrip(code); head = 1, tail = 0)  # drop one leading `?`
+        return _help(query, mod)
+    end
     try
         thunk = () -> include_string(mod, code, "REPL[$id]")
         # Capture stdout, stderr, logging, and the return value, giving us
@@ -90,6 +94,9 @@ function _evaluate(code::AbstractString, id::Integer, mod::Union{Module, Nothing
 end
 
 _echo_object(object) = true
+# The REPL prints nothing for a `nothing` result; match that rather than echoing
+# the literal "nothing". `display`, which returns `nothing`, is the common case.
+_echo_object(::Nothing) = false
 
 function _show_object(buffer, result, mod)
     # Mimic REPL display settings: limit output size, no color codes
@@ -113,6 +120,47 @@ function _error_message(buffer, result, id)
     # invokelatest: a user-defined exception type may have been created during
     # this request, after the worker's world age was fixed.
     return Base.invokelatest(showerror, buffer, result.value.error, bt)
+end
+
+#
+# Help mode.
+#
+
+# A query whose first non-space character is `?` asks for documentation, matching
+# the REPL's help mode. `?x` is brief help, `??x` extended.
+_is_help_query(code::AbstractString) = startswith(lstrip(code), '?')
+
+# Render a docs object (Markdown.MD, or nothing for apropos) to plain text.
+function _render_md(docs, mod::Module)
+    docs === nothing && return ""
+    buffer = IOBuffer()
+    show(IOContext(buffer, :color => false, :module => mod), MIME"text/plain"(), docs)
+    return String(take!(buffer))
+end
+
+# Two-layer dispatch, mirroring `_revise`. The REPL extension overrides
+# `__help(::Nothing, ...)` with the full `helpmode` (operators, keywords, macros,
+# apropos). Without REPL, the `::Any` fallback uses `@doc`, which covers bindings,
+# operators, and macros.
+_help(query::AbstractString, mod::Module) = __help(nothing, query, mod)
+
+function __help(::Any, query::AbstractString, mod::Module)
+    expr = Meta.parse(query; raise = false)
+    docs = try
+        Core.eval(
+            mod,
+            Expr(
+                :macrocall,
+                GlobalRef(Core, Symbol("@doc")),
+                LineNumberNode(@__LINE__, Symbol(@__FILE__)),
+                expr,
+            ),
+        )
+    catch
+        nothing
+    end
+    isnothing(docs) && return (; output = "No documentation found for `$query`.", errored = false)
+    return (; output = _render_md(docs, mod), errored = false)
 end
 
 #

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 REPLicant = "8acbef56-6722-412a-9f59-5674813d37bb"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/test/code_evaluation_tests.jl
+++ b/test/code_evaluation_tests.jl
@@ -56,13 +56,21 @@ end
     mod = Module()
     result = REPLicant._evaluate("", 1, mod)
     @test !result.errored
-    @test strip(result.output) == "nothing"
+    @test strip(result.output) == ""
 end
 
 @testitem "eval_nothing_result" tags = [:code_evaluation] begin
     mod = Module()
     result = REPLicant._evaluate("nothing", 1, mod)
-    @test strip(result.output) == "nothing"
+    @test strip(result.output) == ""
+end
+
+@testitem "eval_non_nothing_value_echoes" tags = [:code_evaluation] begin
+    mod = Module()
+    # Only `nothing` is suppressed; other falsy-looking values still echo.
+    @test strip(REPLicant._evaluate("missing", 1, mod).output) == "missing"
+    @test strip(REPLicant._evaluate("0", 1, mod).output) == "0"
+    @test strip(REPLicant._evaluate("\"\"", 1, mod).output) == "\"\""
 end
 
 @testitem "eval_array_display" tags = [:code_evaluation] begin

--- a/test/help_mode_tests.jl
+++ b/test/help_mode_tests.jl
@@ -1,0 +1,35 @@
+@testitem "help_query_detection" tags = [:help_mode] begin
+    @test REPLicant._is_help_query("?x")
+    @test REPLicant._is_help_query("  ?x")
+    @test !REPLicant._is_help_query("x")
+    @test !REPLicant._is_help_query("")
+end
+
+@testitem "help_doc_fallback" tags = [:help_mode] begin
+    mod = Module()
+    # A non-`nothing` first arg always dispatches to the `@doc` fallback, even when
+    # the REPL extension is loaded, so this exercises the headless path directly.
+    @test contains(REPLicant.__help(0, "println", mod).output, "println")
+    @test !REPLicant.__help(0, "println", mod).errored
+
+    # Operators resolve through `@doc` too.
+    @test contains(REPLicant.__help(0, "+", mod).output, "+")
+
+    # An undefined binding is graceful: no docs, no error.
+    undefined = REPLicant.__help(0, "nonexistent_xyz", mod)
+    @test !undefined.errored
+    @test contains(undefined.output, "No documentation found")
+end
+
+@testitem "help_full_helpmode" tags = [:help_mode] begin
+    # Loading REPL activates the extension, overriding `__help(::Nothing, ...)`
+    # with the full `helpmode`. Only `helpmode` documents keywords, so the `for`
+    # doc confirms the extension path. End-to-end through `_evaluate` exercises the
+    # `?`-strip and dispatch.
+    import REPL
+    mod = Module()
+    result = REPLicant._evaluate("?for", 1, mod)
+    @test !result.errored
+    @test contains(result.output, "for")
+    @test contains(result.output, "loop")
+end

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -16,10 +16,10 @@
         # the Julia and JET versions (JET 0.10 on Julia 1.12), so the ratchet runs
         # only there.
         JET_JULIA = v"1.12"
-        # Below the pre-frame baseline (312): the framed protocol's frame functions
-        # carry concrete types end to end, which also tightened a few inherited
-        # socket-path instabilities.
-        SOUND_LIMIT = 310   # JET.report_package(REPLicant; mode = :sound)
+        # Up from 310: help mode's `@doc` fallback evaluates and `show`s a docs
+        # object of unknown type, so `_help`/`__help`/`_render_md` add a few
+        # intentional dynamic-dispatch reports over `Any`.
+        SOUND_LIMIT = 314   # JET.report_package(REPLicant; mode = :sound)
         OPT_LIMIT = 0       # JET.report_opt on _parse_client_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)


### PR DESCRIPTION
Two REPL-parity fixes to the server's evaluation path.

Help mode: code beginning with `?` returns documentation. When REPL is
loaded (the interactive server, the default) a `REPLicantREPLExt`
extension renders the full `helpmode`, covering operators, keywords,
macros, and `?"text"` apropos search. A headless server falls back to
`@doc`, which covers bindings, operators, and macros. The two-layer
`_help`/`__help` dispatch mirrors the existing Revise integration. `?name`
is brief help, `??name` extended, matching the REPL's mode-switch.

Echo: a `nothing` result now prints nothing via `_echo_object(::Nothing)`,
matching the REPL. `display(x)` returns `nothing`, so it no longer leaves
a trailing `nothing` after its output.

REPL goes in as a weakdep plus extension to keep the runtime stdlib-only.
The base `@doc` fallback evaluates and shows a docs object of unknown type,
so the JET sound ratchet rises from 310 to 314 for that dynamic dispatch.
