### PR TITLE
feat(repl): signal remote eval in the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Show remote evaluation in the interactive server's REPL: while a `julia +rpc` request runs, the `julia>` prompt turns yellow and the terminal title shows a busy marker, reverting when it completes [#34]
 - Add a help mode: code beginning with `?` returns documentation, like the REPL. With REPL loaded (the interactive server) it is the full `helpmode`, covering operators, keywords, macros, and `?"text"` apropos search; a headless server falls back to `@doc` for bindings, operators, and macros. `??name` gives extended help [#33]
 - Gate CI on a Dendro code-quality scan of the package source: a separate Julia 1.12 job fails the build on high-complexity bands or duplicate, stub, and swallowed-error flags [#28]
 
@@ -72,3 +73,4 @@ Initial Public Release
 [#28]: https://github.com/MichaelHatherly/REPLicant.jl/issues/28
 [#32]: https://github.com/MichaelHatherly/REPLicant.jl/issues/32
 [#33]: https://github.com/MichaelHatherly/REPLicant.jl/issues/33
+[#34]: https://github.com/MichaelHatherly/REPLicant.jl/issues/34

--- a/ext/REPLicantREPLExt.jl
+++ b/ext/REPLicantREPLExt.jl
@@ -2,6 +2,7 @@ module REPLicantREPLExt
 
 import REPLicant
 import REPL
+import REPL.LineEdit
 
 # Override the base __help fallback when REPL is available, rendering the full
 # help mode: operators, keywords, macros, and apropos `?"text"` search.
@@ -15,6 +16,78 @@ function REPLicant.__help(::Nothing, query::AbstractString, mod::Module)
     catch error
         (; output = "ERROR: $(error)", errored = true)
     end
+end
+
+#
+# Busy indicator: recolor the `julia>` prompt and set the terminal title while a
+# remote evaluation is in flight.
+#
+
+const BUSY_COLOR = Base.text_colors[:yellow]
+const INSTALL_LOCK = ReentrantLock()
+const INSTALLED = Ref(false)
+const TERMINAL = Ref{Any}(nothing)
+
+# The interactive `julia>` prompt among the REPL's modes, found by its rendered
+# text rather than position to avoid coupling to mode ordering.
+function _julia_prompt(repl)
+    for mode in repl.interface.modes
+        mode isa LineEdit.Prompt || continue
+        endswith(LineEdit.prompt_string(mode.prompt), "julia> ") && return mode
+    end
+    return nothing
+end
+
+# Install the busy hooks once. The server starts from startup.jl before the
+# interactive REPL exists, so resolve `active_repl` lazily on first signal.
+function _install!()
+    INSTALLED[] && return true
+    return lock(INSTALL_LOCK) do
+        INSTALLED[] && return true
+        (isdefined(Base, :active_repl) && Base.active_repl isa REPL.LineEditREPL) || return false
+        repl = Base.active_repl
+        prompt = _julia_prompt(repl)
+        prompt === nothing && return false
+        # The prefix carries no display width, so recoloring never disturbs the
+        # cursor math; idle restores the REPL's configured color.
+        original_prefix = prompt.prompt_prefix
+        prompt.prompt_prefix =
+            () -> REPLicant._is_busy() ? BUSY_COLOR : LineEdit.prompt_string(original_prefix)
+        TERMINAL[] = repl.t
+        INSTALLED[] = true
+        return true
+    end
+end
+
+function REPLicant.__notify_busy(::Nothing)
+    _install!() || return nothing
+    busy = REPLicant._is_busy()
+
+    # OSC 2 sets the terminal title on the captured real terminal, bypassing the
+    # stdout redirection that eval installs.
+    terminal = TERMINAL[]
+    if terminal !== nothing
+        title = busy ? "● julia — remote eval" : "julia"
+        print(terminal, "\e]2;", title, "\a")
+    end
+
+    # Repaint the prompt so the recolor shows while the user sits idle. Uses the
+    # same async channel the REPL uses for the Pkg-mode switch; absent on Julia
+    # 1.10, where the recolor lands on the next natural render.
+    repl = Base.active_repl
+    if isdefined(repl, :mistate) && repl.mistate !== nothing && hasproperty(repl.mistate, :async_channel)
+        try
+            put!(
+                repl.mistate.async_channel, function (s)
+                    LineEdit.refresh_line(s)
+                    return :ok
+                end
+            )
+        catch  # dendro-ignore: empty_catch -- async channel closed during REPL shutdown
+        end
+    end
+
+    return nothing
 end
 
 end

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -164,6 +164,39 @@ function __help(::Any, query::AbstractString, mod::Module)
 end
 
 #
+# Busy indicator.
+#
+
+# Depth of in-flight remote evaluations. A counter, not a flag, so overlapping or
+# nested signals compose; the worker is sequential today, so depth is 0 or 1.
+const REMOTE_EVAL_DEPTH = Threads.Atomic{Int}(0)
+
+# True while at least one remote evaluation is running. Read from the REPL render
+# thread by the prompt; the atomic gives a consistent value.
+_is_busy() = REMOTE_EVAL_DEPTH[] > 0
+
+# Two-layer dispatch, mirroring `_revise`/`_help`. The REPL extension overrides
+# `__notify_busy(::Nothing)` to recolor the prompt and set the terminal title.
+# Without REPL the `::Any` fallback does nothing.
+function _notify_busy(delta::Int)
+    Threads.atomic_add!(REMOTE_EVAL_DEPTH, delta)
+    __notify_busy(nothing)
+    return nothing
+end
+__notify_busy(::Any) = nothing
+
+# Evaluate a remote request while signaling the prompt that work is in flight.
+# Pings never reach here, so the indicator reflects only real evaluations.
+function _evaluate_request(code::AbstractString, id::Integer, mod::Union{Module, Nothing})
+    _notify_busy(1)
+    return try
+        _evaluate(code, id, mod)
+    finally
+        _notify_busy(-1)
+    end
+end
+
+#
 # Revise integration.
 #
 

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -140,7 +140,7 @@ function _handle_client(sock::IO, id::Integer, mod::Union{Module, Nothing}, read
 
         verbose && @info "Received code" id code = Text(frame.body)
 
-        result = _evaluate(frame.body, id, mod)
+        result = _evaluate_request(frame.body, id, mod)
         _write_frame(sock, result.errored ? RESPONSE_ERR : RESPONSE_OK, result.output)
 
         verbose && @info "Sent result" id result = Text(result.output)

--- a/test/protocol_tests.jl
+++ b/test/protocol_tests.jl
@@ -182,6 +182,25 @@ end
     end
 end
 
+@testitem "eval_runs_while_busy" tags = [:protocol] setup = [Utilities] begin
+    Utilities.withserver() do server, mod, port
+        # Code is evaluated while the busy signal is set, so a remote eval can
+        # observe `_is_busy()` as true. Outside the eval the server is idle.
+        Core.eval(mod, :(import REPLicant))
+        @test Utilities.request(port, "REPLicant._is_busy()") == "true"
+        @test !REPLicant._is_busy()
+    end
+end
+
+@testitem "ping_leaves_idle" tags = [:protocol] setup = [Utilities] begin
+    Utilities.withserver() do server, mod, port
+        # A liveness ping never enters the eval path, so it never marks busy.
+        frame = Utilities.requestframe(port, REPLicant.REQUEST_PING, "")
+        @test frame.type == REPLicant.RESPONSE_PONG
+        @test !REPLicant._is_busy()
+    end
+end
+
 @testitem "noncompliant_frame_rejected" tags = [:protocol] setup = [Utilities] begin
     import Sockets
 

--- a/test/utility_function_tests.jl
+++ b/test/utility_function_tests.jl
@@ -39,6 +39,31 @@ end
     end
 end
 
+@testitem "busy_depth_counter" tags = [:utilities] begin
+    # Busy state is a depth counter: nested signals stack, and only the matching
+    # number of decrements clears it. Restored to idle at the end.
+    @test !REPLicant._is_busy()
+    REPLicant._notify_busy(1)
+    @test REPLicant._is_busy()
+    REPLicant._notify_busy(1)
+    @test REPLicant._is_busy()
+    REPLicant._notify_busy(-1)
+    @test REPLicant._is_busy()
+    REPLicant._notify_busy(-1)
+    @test !REPLicant._is_busy()
+end
+
+@testitem "busy_hook_safe_without_repl" tags = [:utilities] begin
+    import REPL  # loads the REPL extension, which overrides __notify_busy
+    # The server starts before any interactive REPL exists, so the hook must be a
+    # safe no-op when `Base.active_repl` is unset while the counter still tracks.
+    @test !REPLicant._is_busy()
+    REPLicant._notify_busy(1)
+    @test REPLicant._is_busy()
+    REPLicant._notify_busy(-1)
+    @test !REPLicant._is_busy()
+end
+
 @testitem "revise_dispatch" tags = [:utilities] begin
     # Test the revise dispatch mechanism
     # Without Revise loaded, should just call function directly


### PR DESCRIPTION
The interactive server shares its module with `julia +rpc` clients but
gave no sign when a remote eval was running. A process-global depth
counter tracks in-flight remote evaluations; the REPL extension recolors
the `julia>` prompt and sets the terminal title while busy, reverting
when idle. Pings are excluded, so the indicator reflects only real
evaluations.

The REPL machinery stays in the weakdep extension. The core adds only a
`Threads.Atomic` counter and a two-layer hook, keeping the runtime
stdlib-only.
