### PR TITLE
fix(server): answer pings off the worker queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Answer liveness pings off the worker queue and time the probe out quickly, so `ls` and server resolution stay responsive while a server is mid-evaluation instead of waiting on the request timeout [#35]
+- Point protocol magic and version mismatch errors at reinstalling the rpc channel, since the usual cause is a client and server on different REPLicant versions [#35]
 - Stop the client from crashing when its output pipe closes early (e.g. piping through `head`): the broken-pipe error is swallowed [#32]
 - Capture `display(x)` output, which previously bypassed the result because it writes through the display stack rather than stdout [#32]
 - Suppress the `nothing` echo: a `nothing` result now prints nothing, matching the REPL, so `display(x)` no longer leaves a trailing `nothing` [#33]
@@ -74,3 +76,4 @@ Initial Public Release
 [#32]: https://github.com/MichaelHatherly/REPLicant.jl/issues/32
 [#33]: https://github.com/MichaelHatherly/REPLicant.jl/issues/33
 [#34]: https://github.com/MichaelHatherly/REPLicant.jl/issues/34
+[#35]: https://github.com/MichaelHatherly/REPLicant.jl/issues/35

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -16,7 +16,16 @@
 #
 
 const READ_TIMEOUT_SECONDS = 30.0
+# Liveness probes are answered off the worker queue, so a live server always
+# replies in milliseconds. A short timeout keeps `ls` and resolution snappy and
+# lets a wedged or version-skewed peer read as dead quickly.
+const PING_TIMEOUT_SECONDS = 2.0
 const MAX_REQUEST_BYTES = 16 * 1024 * 1024  # 16MB
+
+# Appended to magic/version mismatch errors. A peer that fails the header checks
+# is usually a client or server on a different REPLicant version, which the
+# `julia +rpc` channel does not catch on its own.
+const VERSION_SKEW_HELP = "The client and server may be running different REPLicant versions. Reinstall the rpc channel: julia -e 'using REPLicant; REPLicant.install_channel(force = true)'"
 
 const PROTOCOL_MAGIC = Vector{UInt8}("REPL")
 const PROTOCOL_VERSION = 0x01
@@ -71,11 +80,11 @@ function _parse_header(header::Vector{UInt8}, valid_types::Tuple{Vararg{UInt8}},
     buffer = IOBuffer(header)
     magic = read(buffer, length(PROTOCOL_MAGIC))
     magic == PROTOCOL_MAGIC ||
-        error("Unknown protocol: expected magic \"REPL\", got $(repr(String(magic)))")
+        error("Unknown protocol: expected magic \"REPL\", got $(repr(String(magic))). $VERSION_SKEW_HELP")
 
     version = read(buffer, UInt8)
     version == PROTOCOL_VERSION ||
-        error("Protocol version mismatch: expected $(PROTOCOL_VERSION), got $version")
+        error("Protocol version mismatch: expected $(PROTOCOL_VERSION), got $version. $VERSION_SKEW_HELP")
 
     type = read(buffer, UInt8)
     any(==(type), valid_types) || error("Unknown message type: $type")
@@ -126,33 +135,29 @@ function _reject_at_capacity(sock::IO, id, read_timeout_seconds)
     end
 end
 
-function _handle_client(sock::IO, id::Integer, mod::Union{Module, Nothing}, read_timeout_seconds, verbose)
+# Log a handler failure and try to tell the client, tolerating a socket the peer
+# has already closed.
+function _reply_error(sock::IO, id::Integer, error)
+    @error "Error handling client" id error
+    try
+        _write_frame(sock, RESPONSE_ERR, sprint(showerror, error))
+    catch error
+        # Client disconnected before we could send the error.
+        @error "Failed to send error frame to client" id error
+    end
+    return nothing
+end
+
+function _handle_eval(sock::IO, id::Integer, code::AbstractString, mod::Union{Module, Nothing}, verbose)
     return try
-        frame = _read_frame(sock, REQUEST_TYPES; timeout_seconds = read_timeout_seconds)
+        verbose && @info "Received code" id code = Text(code)
 
-        # Bare disconnect: nothing to reply to.
-        isnothing(frame) && return
-
-        if frame.type == REQUEST_PING
-            _write_frame(sock, RESPONSE_PONG, "")
-            return
-        end
-
-        verbose && @info "Received code" id code = Text(frame.body)
-
-        result = _evaluate_request(frame.body, id, mod)
+        result = _evaluate_request(code, id, mod)
         _write_frame(sock, result.errored ? RESPONSE_ERR : RESPONSE_OK, result.output)
 
         verbose && @info "Sent result" id result = Text(result.output)
     catch error
-        @error "Error handling client" id error
-        try
-            # Inform the client about a protocol or framing error.
-            _write_frame(sock, RESPONSE_ERR, sprint(showerror, error))
-        catch error
-            # Client disconnected before we could send the error.
-            @error "Failed to send error frame to client" id error
-        end
+        _reply_error(sock, id, error)
     finally
         # Always close the socket to free resources and signal EOF to the client.
         close(sock)

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -66,12 +66,12 @@ end
 # Probe a server with a ping frame, expecting a pong. A different-version server
 # fails the version check and reads as dead, which is the intended lockstep
 # behavior. Matches the liveness check the CLI uses for `ls`.
-function _ping(port::Integer)
+function _ping(port::Integer; timeout_seconds = PING_TIMEOUT_SECONDS)
     try
         sock = Sockets.connect(Sockets.localhost, port)
         try
             _write_frame(sock, REQUEST_PING, "")
-            frame = _read_frame(sock, RESPONSE_TYPES)
+            frame = _read_frame(sock, RESPONSE_TYPES; timeout_seconds)
             return !isnothing(frame) && frame.type == RESPONSE_PONG
         finally
             close(sock)

--- a/src/server.jl
+++ b/src/server.jl
@@ -113,10 +113,13 @@ function Base.show(io::IO, ::MIME"text/plain", srv::Server)
     return
 end
 
-# Request struct to hold client connection information
+# An evaluation handed from the dispatcher to the worker: the connection to reply
+# on, its id, and the code to run. Pings never become a `ClientRequest`; they are
+# answered in the dispatcher.
 struct ClientRequest
     socket::Sockets.TCPSocket
     id::Int
+    code::String
 end
 
 """
@@ -229,11 +232,11 @@ function _spawn_worker(request_queue, active_connections, srv::Server)
                 for request in request_queue
                     try
                         _revise(
-                            _handle_client,
+                            _handle_eval,
                             request.socket,
                             request.id,
+                            request.code,
                             srv.mod,
-                            srv.read_timeout_seconds,
                             srv.verbose,
                         )
                     finally
@@ -257,22 +260,63 @@ function _accept_loop(server, request_queue, active_connections, srv::Server)
         # assert it so the socket stays concretely typed through the accept loop.
         sock = Sockets.accept(server)::Sockets.TCPSocket
         id += 1
+        _admit(sock, id, request_queue, active_connections, srv)
+    end
+    return
+end
 
-        # Check if at capacity
-        if active_connections[] >= srv.max_connections
-            srv.verbose && @warn "Connection rejected - server at capacity" id current =
-                active_connections[] max = srv.max_connections
-            # Reject off the accept loop so draining the request never blocks
-            # accepting other connections.
-            @async _reject_at_capacity(sock, id, srv.read_timeout_seconds)
+# Admit one accepted connection: reject at capacity, else count it and dispatch it
+# off the accept loop. A function barrier so the spawned tasks capture stable
+# arguments instead of the loop's reassigned `sock`/`id`, which would box.
+function _admit(
+        sock::Sockets.TCPSocket, id::Int, request_queue::Channel{ClientRequest},
+        active_connections::Threads.Atomic{Int}, srv::Server,
+    )
+    if active_connections[] >= srv.max_connections
+        srv.verbose && @warn "Connection rejected - server at capacity" id current =
+            active_connections[] max = srv.max_connections
+        # Reject off the accept loop so draining the request never blocks accepting.
+        @async _reject_at_capacity(sock, id, srv.read_timeout_seconds)
+    else
+        Threads.atomic_add!(active_connections, 1)
+        srv.verbose &&
+            @info "Client connected" id peer = Sockets.getpeername(sock) active =
+            active_connections[]
+        # Dispatch off the accept loop so reading the frame and answering a ping
+        # never blocks accepting other connections.
+        @async _dispatch(sock, id, request_queue, active_connections, srv)
+    end
+    return
+end
+
+# Per-connection dispatcher. Reads one frame, answers a ping immediately so
+# liveness never queues behind an evaluation, and hands an eval to the worker.
+# Pings, framing errors, and bare disconnects release the connection here; the
+# worker releases an eval connection when it finishes evaluating.
+function _dispatch(
+        sock::Sockets.TCPSocket, id::Int, request_queue::Channel{ClientRequest},
+        active_connections::Threads.Atomic{Int}, srv::Server,
+    )
+    enqueued = false
+    try
+        frame = _read_frame(sock, REQUEST_TYPES; timeout_seconds = srv.read_timeout_seconds)
+        if isnothing(frame)
+            return  # bare disconnect, nothing to reply to
+        elseif frame.type == REQUEST_PING
+            _write_frame(sock, RESPONSE_PONG, "")
+            srv.verbose && @info "Answered ping" id
         else
-            # Accept connection and increment counter
-            Threads.atomic_add!(active_connections, 1)
-            srv.verbose &&
-                @info "Client connected" id peer = Sockets.getpeername(sock) active =
-                active_connections[]
-            request = ClientRequest(sock, id)
-            put!(request_queue, request)
+            put!(request_queue, ClientRequest(sock, id, frame.body))
+            enqueued = true
+        end
+    catch error
+        _reply_error(sock, id, error)
+    finally
+        # The worker owns the connection once enqueued; otherwise release it here.
+        if !enqueued
+            close(sock)
+            Threads.atomic_sub!(active_connections, 1)
+            srv.verbose && @info "Client disconnected" id
         end
     end
     return

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -16,10 +16,10 @@
         # the Julia and JET versions (JET 0.10 on Julia 1.12), so the ratchet runs
         # only there.
         JET_JULIA = v"1.12"
-        # Up from 310: help mode's `@doc` fallback evaluates and `show`s a docs
-        # object of unknown type, so `_help`/`__help`/`_render_md` add a few
-        # intentional dynamic-dispatch reports over `Any`.
-        SOUND_LIMIT = 314   # JET.report_package(REPLicant; mode = :sound)
+        # Help mode's `@doc` fallback evaluates and `show`s a docs object of
+        # unknown type, so `_help`/`__help`/`_render_md` contribute intentional
+        # dynamic-dispatch reports over `Any`; the rest are socket IO and logging.
+        SOUND_LIMIT = 308   # JET.report_package(REPLicant; mode = :sound)
         OPT_LIMIT = 0       # JET.report_opt on _parse_client_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)

--- a/test/protocol_tests.jl
+++ b/test/protocol_tests.jl
@@ -49,7 +49,11 @@ end
         e
     end
     @test err isa Exception
-    @test contains(sprint(showerror, err), "protocol")
+    message = sprint(showerror, err)
+    @test contains(message, "protocol")
+    # The most common cause is a peer on a different REPLicant version, so the
+    # error points at reinstalling the channel.
+    @test contains(message, "install_channel")
 end
 
 @testitem "frame_version_mismatch_rejected" tags = [:protocol, :frame] begin
@@ -69,7 +73,9 @@ end
         e
     end
     @test err isa Exception
-    @test contains(sprint(showerror, err), "version")
+    message = sprint(showerror, err)
+    @test contains(message, "version")
+    @test contains(message, "install_channel")
 end
 
 @testitem "frame_unknown_type_rejected" tags = [:protocol, :frame] begin
@@ -199,6 +205,39 @@ end
         @test frame.type == REPLicant.RESPONSE_PONG
         @test !REPLicant._is_busy()
     end
+end
+
+@testitem "ping_answered_during_eval" tags = [:protocol] setup = [Utilities] begin
+    import Sockets
+
+    Utilities.withserver() do server, mod, port
+        # Occupy the worker with a long evaluation.
+        busy = Utilities.sendframe(Sockets.connect(Sockets.localhost, port), "sleep(2); 1")
+        sleep(0.2)  # let the eval reach the worker
+        # The ping must be answered off the worker queue, not behind the 2s eval.
+        elapsed = @elapsed answered = REPLicant._ping(port)
+        @test answered
+        @test elapsed < 1.0
+        @test strip(Utilities.readresp(busy)) == "1"
+        close(busy)
+    end
+end
+
+@testitem "ping_times_out_on_silent_peer" tags = [:protocol, :timeout] begin
+    import REPLicant
+    import Sockets
+
+    # A peer that accepts but never replies must read as dead within the ping
+    # timeout, not the much longer request timeout.
+    listener = Sockets.listen(Sockets.localhost, 0)
+    port = Int(Sockets.getsockname(listener)[2])
+    held = Ref{Any}(nothing)
+    acceptor = @async (held[] = Sockets.accept(listener))
+    elapsed = @elapsed result = REPLicant._ping(port; timeout_seconds = 0.5)
+    @test result == false
+    @test elapsed < 5
+    held[] !== nothing && close(held[])
+    close(listener)
 end
 
 @testitem "noncompliant_frame_rejected" tags = [:protocol] setup = [Utilities] begin


### PR DESCRIPTION
Pings were queued behind evaluations on the single worker, so a liveness
probe could not return until the in-flight evaluation finished. `_ping`
runs on every `ls` and on server resolution, so a server busy longer than
the probe timeout looked dead and its registry entry was pruned. The
accept loop now dispatches each connection on its own task: pings are
answered immediately, evaluations are queued for the worker. With
liveness decoupled from evaluation load, the probe uses a short 2s
timeout, so a wedged or version-skewed peer reads as dead quickly instead
of stalling on the 30s request timeout.

Per-connection dispatch goes through `_admit`, a function barrier so the
spawned tasks capture stable arguments rather than the accept loop's
reassigned `sock`/`id`, which would box.

Protocol magic and version mismatch errors now point at reinstalling the
rpc channel, the usual cause being a client and server on different
REPLicant versions.
