### PR TITLE
feat(repl): animate the busy prompt indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Capture subprocess and C-library output in rpc evals: a remote eval redirects fd 1/2 to its own pipe for its duration, so `run(cmd)` and C code writing directly to the file descriptors are returned to the client instead of leaking to the server's terminal [#36]
-- Show remote evaluation in the interactive server's REPL: while a `julia +rpc` request runs, the `julia>` prompt turns yellow and the terminal title shows a busy marker, reverting when it completes [#34]
+- Show remote evaluation in the interactive server's REPL: while a `julia +rpc` request runs, a single underscore sweeps through the prompt in every REPL mode and the terminal title shows a busy marker, reverting when it completes. Prompt colors are left at their defaults [#34][#37]
 - Add a help mode: code beginning with `?` returns documentation, like the REPL. With REPL loaded (the interactive server) it is the full `helpmode`, covering operators, keywords, macros, and `?"text"` apropos search; a headless server falls back to `@doc` for bindings, operators, and macros. `??name` gives extended help [#33]
 - Gate CI on a Dendro code-quality scan of the package source: a separate Julia 1.12 job fails the build on high-complexity bands or duplicate, stub, and swallowed-error flags [#28]
 
@@ -77,6 +77,5 @@ Initial Public Release
 [#28]: https://github.com/MichaelHatherly/REPLicant.jl/issues/28
 [#32]: https://github.com/MichaelHatherly/REPLicant.jl/issues/32
 [#33]: https://github.com/MichaelHatherly/REPLicant.jl/issues/33
-[#34]: https://github.com/MichaelHatherly/REPLicant.jl/issues/34
 [#35]: https://github.com/MichaelHatherly/REPLicant.jl/issues/35
 [#36]: https://github.com/MichaelHatherly/REPLicant.jl/issues/36

--- a/ext/REPLicantREPLExt.jl
+++ b/ext/REPLicantREPLExt.jl
@@ -19,44 +19,69 @@ function REPLicant.__help(::Nothing, query::AbstractString, mod::Module)
 end
 
 #
-# Busy indicator: recolor the `julia>` prompt and set the terminal title while a
+# Busy indicator: animate the `julia>` prompt and set the terminal title while a
 # remote evaluation is in flight.
 #
 
-const BUSY_COLOR = Base.text_colors[:yellow]
 const INSTALL_LOCK = ReentrantLock()
 const INSTALLED = Ref(false)
 const TERMINAL = Ref{Any}(nothing)
 
-# The interactive `julia>` prompt among the REPL's modes, found by its rendered
-# text rather than position to avoid coupling to mode ordering.
-function _julia_prompt(repl)
-    for mode in repl.interface.modes
-        mode isa LineEdit.Prompt || continue
-        endswith(LineEdit.prompt_string(mode.prompt), "julia> ") && return mode
-    end
+# Animation state. `FRAME` advances one step per timer tick; `ANIM` holds the
+# running timer so a second busy signal does not start a second one. Frame cadence
+# in seconds.
+const FRAME = Ref(0)
+const ANIM = Ref{Union{Timer, Nothing}}(nothing)
+const FRAME_SECONDS = 0.12
+
+# Wrap one prompt mode's text with the busy animation. The closure captures this
+# mode's own original prompt, so idle restores exactly what was there, in its
+# default color. The animated frame keeps the prompt's display width, so swapping
+# it in never shifts typed input.
+function _animate!(prompt)
+    original_prompt = prompt.prompt
+    prompt.prompt =
+        () -> REPLicant._is_busy() ?
+        REPLicant._busy_frame(LineEdit.prompt_string(original_prompt), FRAME[]) :
+        LineEdit.prompt_string(original_prompt)
     return nothing
 end
 
-# Install the busy hooks once. The server starts from startup.jl before the
-# interactive REPL exists, so resolve `active_repl` lazily on first signal.
+# Install the busy hooks once, across every prompt mode (julia, pkg, help, shell).
+# The server starts from startup.jl before the interactive REPL exists, so resolve
+# `active_repl` lazily on first signal.
 function _install!()
     INSTALLED[] && return true
     return lock(INSTALL_LOCK) do
         INSTALLED[] && return true
         (isdefined(Base, :active_repl) && Base.active_repl isa REPL.LineEditREPL) || return false
         repl = Base.active_repl
-        prompt = _julia_prompt(repl)
-        prompt === nothing && return false
-        # The prefix carries no display width, so recoloring never disturbs the
-        # cursor math; idle restores the REPL's configured color.
-        original_prefix = prompt.prompt_prefix
-        prompt.prompt_prefix =
-            () -> REPLicant._is_busy() ? BUSY_COLOR : LineEdit.prompt_string(original_prefix)
+        for mode in repl.interface.modes
+            mode isa LineEdit.Prompt && _animate!(mode)
+        end
         TERMINAL[] = repl.t
         INSTALLED[] = true
         return true
     end
+end
+
+# Repaint the prompt from the REPL render thread. Uses the same async channel the
+# REPL uses for the Pkg-mode switch; absent on Julia 1.10, where the change lands
+# on the next natural render.
+function _request_refresh()
+    repl = Base.active_repl
+    if isdefined(repl, :mistate) && repl.mistate !== nothing && hasproperty(repl.mistate, :async_channel)
+        try
+            put!(
+                repl.mistate.async_channel, function (s)
+                    LineEdit.refresh_line(s)
+                    return :ok
+                end
+            )
+        catch  # dendro-ignore: empty_catch -- async channel closed during REPL shutdown
+        end
+    end
+    return nothing
 end
 
 function REPLicant.__notify_busy(::Nothing)
@@ -71,20 +96,20 @@ function REPLicant.__notify_busy(::Nothing)
         print(terminal, "\e]2;", title, "\a")
     end
 
-    # Repaint the prompt so the recolor shows while the user sits idle. Uses the
-    # same async channel the REPL uses for the Pkg-mode switch; absent on Julia
-    # 1.10, where the recolor lands on the next natural render.
-    repl = Base.active_repl
-    if isdefined(repl, :mistate) && repl.mistate !== nothing && hasproperty(repl.mistate, :async_channel)
-        try
-            put!(
-                repl.mistate.async_channel, function (s)
-                    LineEdit.refresh_line(s)
-                    return :ok
-                end
-            )
-        catch  # dendro-ignore: empty_catch -- async channel closed during REPL shutdown
+    # Drive the animation: start a repeating timer on the first busy signal, stop
+    # it when work clears and repaint once to restore the idle prompt.
+    if busy
+        if ANIM[] === nothing
+            ANIM[] = Timer(FRAME_SECONDS; interval = FRAME_SECONDS) do _
+                FRAME[] += 1
+                _request_refresh()
+            end
         end
+    elseif ANIM[] !== nothing
+        close(ANIM[])
+        ANIM[] = nothing
+        FRAME[] = 0
+        _request_refresh()
     end
 
     return nothing

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -273,6 +273,23 @@ const REMOTE_EVAL_DEPTH = Threads.Atomic{Int}(0)
 # thread by the prompt; the atomic gives a consistent value.
 _is_busy() = REMOTE_EVAL_DEPTH[] > 0
 
+# One animation frame of a busy prompt, generic across REPL modes. `base` is the
+# idle prompt text (`"julia> "`, `"pkg> "`, `"help?> "`, ...); `marker` is its
+# last non-blank glyph, the `>`-style cursor common to every mode. A `_` sweeps
+# through the label before the marker, swapping one width-1 glyph for another, so
+# `textwidth(base)` holds and the cursor never shifts.
+function _busy_frame(base::AbstractString, n::Int)
+    chars = collect(Char, base)
+    marker = length(chars)
+    while marker > 0 && isspace(chars[marker])
+        marker -= 1
+    end
+    marker == 0 && return String(chars)
+    span = max(marker - 1, 1)
+    chars[mod(n, span) + 1] = '_'
+    return String(chars)
+end
+
 # Two-layer dispatch, mirroring `_revise`/`_help`. The REPL extension overrides
 # `__notify_busy(::Nothing)` to recolor the prompt and set the terminal title.
 # Without REPL the `::Any` fallback does nothing.

--- a/test/utility_function_tests.jl
+++ b/test/utility_function_tests.jl
@@ -64,6 +64,37 @@ end
     @test !REPLicant._is_busy()
 end
 
+@testitem "busy_frame_underscore" tags = [:utilities] begin
+    # The underscore sweep replaces one letter per frame and never changes the
+    # prompt's display width, so typed input never shifts. Only "julia" animates:
+    # the `>` and trailing space stay put.
+    base = "julia> "
+    width = textwidth(base)
+    seen = Int[]
+    for n in 0:12
+        frame = REPLicant._busy_frame(base, n)
+        @test textwidth(frame) == width
+        @test count(==('_'), frame) == 1
+        @test contains(frame, ">")  # the prompt marker is never swept
+        push!(seen, findfirst('_', frame))
+    end
+    @test seen[1:5] == collect(1:5)
+    @test seen[6] == 1  # wraps after the 5 letters of "julia"
+end
+
+@testitem "busy_frame_generic_modes" tags = [:utilities] begin
+    # The animation is generic across REPL modes: it sweeps the label before each
+    # prompt's own marker (last non-blank glyph), never a hardcoded "julia". The
+    # marker stays put and the width holds for every mode.
+    for base in ("pkg> ", "help?> ", "shell> ", "(jl) pkg> ")
+        width = textwidth(base)
+        frame = REPLicant._busy_frame(base, 0)
+        @test textwidth(frame) == width
+        @test count(==('_'), frame) == 1
+        @test endswith(frame, "> ")  # the marker and trailing space survive
+    end
+end
+
 @testitem "revise_dispatch" tags = [:utilities] begin
     # Test the revise dispatch mechanism
     # Without Revise loaded, should just call function directly


### PR DESCRIPTION
The busy indicator recolored the `julia>` prompt yellow, easy to miss and
limited to the julia mode. A single underscore now sweeps through the prompt's
label while a remote eval runs, driven by a repeating timer, and reverts when
the work clears. It runs in every prompt mode, leaves each prompt's default
color untouched, and swaps one width-1 glyph at a time so typed input never
shifts.
