### PR TITLE
feat(client): timeout, kill, and busy status for wedged servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bound the client's wait for a result with `--timeout <seconds>`: an eval that does not respond in time frees the caller with a non-zero exit and a message pointing at `julia +rpc kill`, instead of stalling on a wedged server. Without the flag the client waits as long as the eval runs [#38]
 - Capture subprocess and C-library output in rpc evals: a remote eval redirects fd 1/2 to its own pipe for its duration, so `run(cmd)` and C code writing directly to the file descriptors are returned to the client instead of leaking to the server's terminal [#36]
 - Show remote evaluation in the interactive server's REPL: while a `julia +rpc` request runs, a single underscore sweeps through the prompt in every REPL mode and the terminal title shows a busy marker, reverting when it completes. Prompt colors are left at their defaults [#34][#37]
 - Add a help mode: code beginning with `?` returns documentation, like the REPL. With REPL loaded (the interactive server) it is the full `helpmode`, covering operators, keywords, macros, and `?"text"` apropos search; a headless server falls back to `@doc` for bindings, operators, and macros. `??name` gives extended help [#33]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `julia +rpc kill [--force]` to terminate a server whose worker is wedged on a non-returning eval. The target resolves from the raw registry (no ping), so a server that cannot answer its socket still resolves; `kill` sends SIGTERM, `--force` sends SIGKILL, the only signal that lands on a tight non-yielding loop. Julia cannot interrupt a running task, so killing the process is the recovery [#38]
 - Bound the client's wait for a result with `--timeout <seconds>`: an eval that does not respond in time frees the caller with a non-zero exit and a message pointing at `julia +rpc kill`, instead of stalling on a wedged server. Without the flag the client waits as long as the eval runs [#38]
 - Capture subprocess and C-library output in rpc evals: a remote eval redirects fd 1/2 to its own pipe for its duration, so `run(cmd)` and C code writing directly to the file descriptors are returned to the client instead of leaking to the server's terminal [#36]
 - Show remote evaluation in the interactive server's REPL: while a `julia +rpc` request runs, a single underscore sweeps through the prompt in every REPL mode and the terminal title shows a busy marker, reverting when it completes. Prompt colors are left at their defaults [#34][#37]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,3 +83,4 @@ Initial Public Release
 [#33]: https://github.com/MichaelHatherly/REPLicant.jl/issues/33
 [#35]: https://github.com/MichaelHatherly/REPLicant.jl/issues/35
 [#36]: https://github.com/MichaelHatherly/REPLicant.jl/issues/36
+[#38]: https://github.com/MichaelHatherly/REPLicant.jl/issues/38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Show evaluation state in `julia +rpc ls`: a `STATUS` column reads `idle`, or `busy <n>s` while the server is mid-evaluation, carried in the pong body so a wedged server is visible without a separate probe [#38]
 - Add `julia +rpc kill [--force]` to terminate a server whose worker is wedged on a non-returning eval. The target resolves from the raw registry (no ping), so a server that cannot answer its socket still resolves; `kill` sends SIGTERM, `--force` sends SIGKILL, the only signal that lands on a tight non-yielding loop. Julia cannot interrupt a running task, so killing the process is the recovery [#38]
 - Bound the client's wait for a result with `--timeout <seconds>`: an eval that does not respond in time frees the caller with a non-zero exit and a message pointing at `julia +rpc kill`, instead of stalling on a wedged server. Without the flag the client waits as long as the eval runs [#38]
 - Capture subprocess and C-library output in rpc evals: a remote eval redirects fd 1/2 to its own pipe for its duration, so `run(cmd)` and C code writing directly to the file descriptors are returned to the client instead of leaking to the server's terminal [#36]
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stop discarding the result of an eval that runs longer than 30 seconds: the client read no longer applies the request timeout to the response, so a long compute returns instead of erroring [#38]
 - Answer liveness pings off the worker queue and time the probe out quickly, so `ls` and server resolution stay responsive while a server is mid-evaluation instead of waiting on the request timeout [#35]
 - Point protocol magic and version mismatch errors at reinstalling the rpc channel, since the usual cause is a client and server on different REPLicant versions [#35]
 - Stop the client from crashing when its output pipe closes early (e.g. piping through `head`): the broken-pipe error is swallowed [#32]

--- a/plugins/replicant/skills/replicant/references/evaluate.md
+++ b/plugins/replicant/skills/replicant/references/evaluate.md
@@ -30,6 +30,19 @@ avoids the question.
 Output is REPL-style: captured stdout and stderr first, then the value, or a
 scrubbed error with backtrace.
 
+## Bounding the wait
+
+By default the client waits as long as the eval runs, so a deliberate long compute
+returns its result. To cap the wait, pass `--timeout <seconds>`:
+
+```bash
+julia +rpc --timeout 10 -e 'long_running()'
+```
+
+On expiry the client exits non-zero and prints a message pointing at `julia +rpc
+kill`. The eval keeps running on the server; the timeout only frees the caller.
+See `servers.md` for recovering a wedged server.
+
 ## Help mode
 
 A leading `?` returns documentation, like the REPL's help mode. Use `?name` for

--- a/plugins/replicant/skills/replicant/references/servers.md
+++ b/plugins/replicant/skills/replicant/references/servers.md
@@ -8,10 +8,11 @@ Part of the `replicant` skill; see `SKILL.md`.
 julia +rpc ls
 ```
 
-Lists every live server: `PORT NAME PROJECT JULIA PID STARTED`. A server is rooted
-at the project it started in (git top-level, else the working directory). `julia
-+rpc` from inside that tree selects it. With one server for the project, selection
-is automatic. Disambiguate with:
+Lists every live server: `PORT NAME PROJECT JULIA PID STARTED STATUS`. `STATUS` is
+`idle`, or `busy <n>s` when the server is mid-evaluation (a long compute, or a
+wedge). A server is rooted at the project it started in (git top-level, else the
+working directory). `julia +rpc` from inside that tree selects it. With one server
+for the project, selection is automatic. Disambiguate with:
 
 - `--name <label>`: pick a labeled server (see below).
 - `--port <n>`: target a specific port.
@@ -39,6 +40,21 @@ close(REPLicant.server()) # stop it
 
 Showing the handle reports port, project, name, start time, and limits, read from
 the struct, not the registry.
+
+## Stop a wedged server
+
+A server holding its worker on a non-returning eval (`while true`, a deadlock, a
+blocking read) keeps `ls` showing it `busy` and never evaluates again. Julia
+cannot interrupt a running task, so the recovery is to kill the process:
+
+```bash
+julia +rpc kill            # SIGTERM the resolved server
+julia +rpc kill --force    # SIGKILL, the only signal that lands on a tight loop
+```
+
+`kill` takes the same `--port`/`--name`/`--project` selectors as eval and resolves
+from the registry without pinging, so a server that cannot answer still resolves.
+Killing loses the session state; start a fresh server afterward.
 
 ## Start a server by hand
 

--- a/src/client.jl
+++ b/src/client.jl
@@ -69,18 +69,17 @@ function _candidates_error(candidates, message::AbstractString)
     return ErrorException(String(take!(io)))
 end
 
-# The selection cascade: explicit port wins; else narrow to the deepest project
-# that owns `project`, pick by --name or auto-select the lone server; finally fall
-# back to a global name match.
-function _resolve_port(port::Integer, project::AbstractString, name::AbstractString)
-    port > 0 && return port
-
-    live = _live_entries()
-    isempty(live) && error("no running REPLicant servers found")
+# The selection cascade over `candidates`: narrow to the deepest project that owns
+# `project`, pick by --name or auto-select the lone server; finally fall back to a
+# global name match. Returns the chosen entry.
+function _select_entry(
+        candidates::Vector{RegistryEntry}, project::AbstractString, name::AbstractString,
+    )
+    isempty(candidates) && error("no running REPLicant servers found")
 
     target = _canonical(isempty(project) ? "." : project)
 
-    owning = filter(live) do entry
+    owning = filter(candidates) do entry
         root = _canonical(entry.project)
         root == target || startswith(target, root * Base.Filesystem.path_separator)
     end
@@ -91,9 +90,9 @@ function _resolve_port(port::Integer, project::AbstractString, name::AbstractStr
             index = findfirst(e -> e.name == name, scoped)
             isnothing(index) &&
                 throw(_candidates_error(scoped, "no server named \"$name\" for $target"))
-            return scoped[index].port
+            return scoped[index]
         end
-        length(scoped) == 1 && return scoped[1].port
+        length(scoped) == 1 && return scoped[1]
         throw(
             _candidates_error(
                 scoped,
@@ -103,15 +102,35 @@ function _resolve_port(port::Integer, project::AbstractString, name::AbstractStr
     end
 
     if !isempty(name)
-        named = filter(e -> e.name == name, live)
-        length(named) == 1 && return named[1].port
+        named = filter(e -> e.name == name, candidates)
+        length(named) == 1 && return named[1]
         length(named) > 1 &&
             throw(_candidates_error(named, "multiple servers named \"$name\""))
-    elseif length(live) == 1
-        return live[1].port
+    elseif length(candidates) == 1
+        return candidates[1]
     end
 
-    throw(_candidates_error(live, "could not pick a server for $target"))
+    throw(_candidates_error(candidates, "could not pick a server for $target"))
+end
+
+# Resolve an eval target to a port: an explicit port wins and connects directly;
+# otherwise run the cascade over the live servers.
+function _resolve_port(port::Integer, project::AbstractString, name::AbstractString)
+    port > 0 && return port
+    return _select_entry(_live_entries(), project, name).port
+end
+
+# Resolve a kill target to its registry entry. Unlike eval, this reads the raw
+# registry without pinging, so a wedged server that cannot pong still resolves; an
+# explicit port must name a registered server, since kill needs its pid.
+function _kill_target(port::Integer, project::AbstractString, name::AbstractString)
+    entries = _read_entries()
+    if port > 0
+        index = findfirst(e -> e.port == port, entries)
+        isnothing(index) && error("no REPLicant server registered on port $port")
+        return entries[index]
+    end
+    return _select_entry(entries, project, name)
 end
 
 # Consume the value following a flag at `index`, erroring when the flag ends the
@@ -157,6 +176,37 @@ function _parse_client_args(args)
         index += 1
     end
     return (; port, project, name, code, timeout)
+end
+
+function _parse_kill_args(args)
+    port = -1
+    project = ""
+    name = ""
+    force = false
+    index = 1
+    while index <= length(args)
+        arg = args[index]
+        if startswith(arg, "--port=")
+            port = _parse_port(arg[(length("--port=") + 1):end])
+        elseif arg == "--port"
+            value, index = _take_value(args, index, "--port")
+            port = _parse_port(value)
+        elseif startswith(arg, "--project=")
+            project = arg[(length("--project=") + 1):end]
+        elseif arg == "--project"
+            project, index = _take_value(args, index, "--project")
+        elseif startswith(arg, "--name=")
+            name = arg[(length("--name=") + 1):end]
+        elseif arg == "--name"
+            name, index = _take_value(args, index, "--name")
+        elseif arg == "--force" || arg == "-f"
+            force = true
+        else
+            error("unrecognized argument: $arg")
+        end
+        index += 1
+    end
+    return (; port, project, name, force)
 end
 
 function _parse_port(value::AbstractString)
@@ -253,18 +303,46 @@ function _print_row(out, port, name, project, julia, pid, started)
     )
 end
 
+# Terminate a target server's process. Resolves from the raw registry so a wedged
+# server still resolves, sends SIGTERM (SIGKILL with --force), and removes the
+# registry entry, since a SIGKILL skips the server's own cleanup.
+function _kill_server(args; out::IO = stdout)
+    parsed = _parse_kill_args(args)
+    entry = _kill_target(parsed.port, parsed.project, parsed.name)
+    pid = tryparse(Int, entry.pid)
+    isnothing(pid) && error("registry entry for port $(entry.port) has no valid pid")
+
+    path = _registry_entry_path(entry.port)
+    if !_process_alive(pid)
+        rm(path; force = true)
+        println(out, "REPLicant server on port $(entry.port) (pid $pid) was already gone")
+        return 0
+    end
+
+    _signal_process(pid, parsed.force ? SIGKILL : SIGTERM)
+    rm(path; force = true)
+    action = parsed.force ? "killed" : "terminated"
+    println(out, "$action REPLicant server on port $(entry.port) (pid $pid)")
+    return 0
+end
+
 """
     cli(args = ARGS; out = stdout, err = stderr) -> Int
 
-Forwarding client entrypoint. With a leading `ls`/`list` it prints the live
-servers; otherwise it resolves a target server and forwards code to it, taken
-from `-e` or, when absent, from stdin. Returns a process exit code.
+Forwarding client entrypoint. A leading `ls`/`list` prints the live servers; a
+leading `kill` terminates a resolved server (`--force` for SIGKILL). Otherwise it
+resolves a target server and forwards code to it, taken from `-e` or, when absent,
+from stdin. `--timeout <seconds>` bounds the wait for a result. Returns a process
+exit code.
 """
 function cli(args = ARGS; out::IO = stdout, err::IO = stderr)
     try
         if !isempty(args) && (args[1] == "ls" || args[1] == "list")
             _list_servers(out)
             return 0
+        end
+        if !isempty(args) && args[1] == "kill"
+            return _kill_server(args[2:end]; out)
         end
         parsed = _parse_client_args(args)
         code = isnothing(parsed.code) ? read(stdin, String) : parsed.code

--- a/src/client.jl
+++ b/src/client.jl
@@ -127,6 +127,7 @@ function _parse_client_args(args)
     project = ""
     name = ""
     code = nothing
+    timeout = nothing
     index = 1
     while index <= length(args)
         arg = args[index]
@@ -143,6 +144,11 @@ function _parse_client_args(args)
             name = arg[(length("--name=") + 1):end]
         elseif arg == "--name"
             name, index = _take_value(args, index, "--name")
+        elseif startswith(arg, "--timeout=")
+            timeout = _parse_timeout(arg[(length("--timeout=") + 1):end])
+        elseif arg == "--timeout"
+            value, index = _take_value(args, index, "--timeout")
+            timeout = _parse_timeout(value)
         elseif arg == "-e" || arg == "--eval"
             code, index = _take_value(args, index, "-e")
         else
@@ -150,13 +156,19 @@ function _parse_client_args(args)
         end
         index += 1
     end
-    return (; port, project, name, code)
+    return (; port, project, name, code, timeout)
 end
 
 function _parse_port(value::AbstractString)
     port = tryparse(Int, value)
     isnothing(port) && error("invalid --port: $value")
     return port
+end
+
+function _parse_timeout(value::AbstractString)
+    seconds = tryparse(Float64, value)
+    (isnothing(seconds) || seconds <= 0) && error("invalid --timeout: $value")
+    return seconds
 end
 
 # Write the result, terminating a non-empty payload with a newline so output does
@@ -174,12 +186,27 @@ function _write_payload(io::IO, payload::String)
 end
 
 # Send an eval frame and route the response: `ok` to `out`, `err` to `err`.
-# Returns a process exit code, non-zero when the evaluation errored.
-function _send(port::Integer, code::String; out::IO = stdout, err::IO = stderr)
+# Returns a process exit code, non-zero when the evaluation errored. `timeout_seconds`
+# bounds the wait for the result; `nothing` waits as long as the eval runs.
+function _send(
+        port::Integer, code::String;
+        out::IO = stdout, err::IO = stderr, timeout_seconds = nothing,
+    )
     sock = Sockets.connect(Sockets.localhost, port)
     try
         _write_frame(sock, REQUEST_EVAL, code)
-        frame = _read_frame(sock, RESPONSE_TYPES)
+        frame = try
+            _read_frame(sock, RESPONSE_TYPES; timeout_seconds)
+        catch timeout
+            timeout isa ReadTimeout || rethrow()
+            throw(
+                ErrorException(
+                    "evaluation did not respond within $(timeout.timeout_seconds)s; \
+                    the server may be wedged on a long-running or non-returning eval. \
+                    Recover with: julia +rpc kill",
+                ),
+            )
+        end
         isnothing(frame) && error("server closed the connection without a response")
         if frame.type == RESPONSE_ERR
             _write_payload(err, frame.body)
@@ -242,7 +269,7 @@ function cli(args = ARGS; out::IO = stdout, err::IO = stderr)
         parsed = _parse_client_args(args)
         code = isnothing(parsed.code) ? read(stdin, String) : parsed.code
         target = _resolve_port(parsed.port, parsed.project, parsed.name)
-        return _send(target, code; out, err)
+        return _send(target, code; out, err, timeout_seconds = parsed.timeout)
     catch error
         error isa InterruptException && rethrow()
         message = error isa ErrorException ? error.msg : sprint(showerror, error)

--- a/src/client.jl
+++ b/src/client.jl
@@ -141,6 +141,30 @@ function _take_value(args, index, flag)
     return args[index], index
 end
 
+# Match a server selector (`--port`/`--project`/`--name`) at `index`, shared by the
+# eval and kill parsers. Returns the updated selectors, the advanced index, and
+# whether the flag matched, so each parser handles only its own extra flags.
+function _match_selector(args, index, port, project, name)
+    arg = args[index]
+    if startswith(arg, "--port=")
+        port = _parse_port(arg[(length("--port=") + 1):end])
+    elseif arg == "--port"
+        value, index = _take_value(args, index, "--port")
+        port = _parse_port(value)
+    elseif startswith(arg, "--project=")
+        project = arg[(length("--project=") + 1):end]
+    elseif arg == "--project"
+        project, index = _take_value(args, index, "--project")
+    elseif startswith(arg, "--name=")
+        name = arg[(length("--name=") + 1):end]
+    elseif arg == "--name"
+        name, index = _take_value(args, index, "--name")
+    else
+        return port, project, name, index, false
+    end
+    return port, project, name, index, true
+end
+
 function _parse_client_args(args)
     port = -1
     project = ""
@@ -149,29 +173,19 @@ function _parse_client_args(args)
     timeout = nothing
     index = 1
     while index <= length(args)
-        arg = args[index]
-        if startswith(arg, "--port=")
-            port = _parse_port(arg[(length("--port=") + 1):end])
-        elseif arg == "--port"
-            value, index = _take_value(args, index, "--port")
-            port = _parse_port(value)
-        elseif startswith(arg, "--project=")
-            project = arg[(length("--project=") + 1):end]
-        elseif arg == "--project"
-            project, index = _take_value(args, index, "--project")
-        elseif startswith(arg, "--name=")
-            name = arg[(length("--name=") + 1):end]
-        elseif arg == "--name"
-            name, index = _take_value(args, index, "--name")
-        elseif startswith(arg, "--timeout=")
-            timeout = _parse_timeout(arg[(length("--timeout=") + 1):end])
-        elseif arg == "--timeout"
-            value, index = _take_value(args, index, "--timeout")
-            timeout = _parse_timeout(value)
-        elseif arg == "-e" || arg == "--eval"
-            code, index = _take_value(args, index, "-e")
-        else
-            error("unrecognized argument: $arg")
+        port, project, name, index, matched = _match_selector(args, index, port, project, name)
+        if !matched
+            arg = args[index]
+            if startswith(arg, "--timeout=")
+                timeout = _parse_timeout(arg[(length("--timeout=") + 1):end])
+            elseif arg == "--timeout"
+                value, index = _take_value(args, index, "--timeout")
+                timeout = _parse_timeout(value)
+            elseif arg == "-e" || arg == "--eval"
+                code, index = _take_value(args, index, "-e")
+            else
+                error("unrecognized argument: $arg")
+            end
         end
         index += 1
     end
@@ -185,24 +199,14 @@ function _parse_kill_args(args)
     force = false
     index = 1
     while index <= length(args)
-        arg = args[index]
-        if startswith(arg, "--port=")
-            port = _parse_port(arg[(length("--port=") + 1):end])
-        elseif arg == "--port"
-            value, index = _take_value(args, index, "--port")
-            port = _parse_port(value)
-        elseif startswith(arg, "--project=")
-            project = arg[(length("--project=") + 1):end]
-        elseif arg == "--project"
-            project, index = _take_value(args, index, "--project")
-        elseif startswith(arg, "--name=")
-            name = arg[(length("--name=") + 1):end]
-        elseif arg == "--name"
-            name, index = _take_value(args, index, "--name")
-        elseif arg == "--force" || arg == "-f"
-            force = true
-        else
-            error("unrecognized argument: $arg")
+        port, project, name, index, matched = _match_selector(args, index, port, project, name)
+        if !matched
+            arg = args[index]
+            if arg == "--force" || arg == "-f"
+                force = true
+            else
+                error("unrecognized argument: $arg")
+            end
         end
         index += 1
     end
@@ -269,10 +273,29 @@ function _send(
     end
 end
 
+# Render a pong body as a status: empty is idle, a timestamp is busy with elapsed
+# seconds. A marker that does not parse still reads as busy rather than crashing.
+function _format_status(marker::AbstractString)
+    isempty(marker) && return "idle"
+    since = tryparse(Dates.DateTime, marker)
+    isnothing(since) && return "busy"
+    seconds = max(0, round(Int, (Dates.now() - since).value / 1000))
+    return "busy $(seconds)s"
+end
+
 function _list_servers(out::IO = stdout)
-    live = sort(_live_entries(); by = entry -> entry.port)
-    _print_row(out, "PORT", "NAME", "PROJECT", "JULIA", "PID", "STARTED")
-    for entry in live
+    rows = Tuple{RegistryEntry, String}[]
+    for entry in _read_entries()
+        status = _ping_status(entry.port)
+        if isnothing(status)
+            rm(_registry_entry_path(entry.port); force = true)
+        else
+            push!(rows, (entry, status))
+        end
+    end
+    sort!(rows; by = row -> row[1].port)
+    _print_row(out, "PORT", "NAME", "PROJECT", "JULIA", "PID", "STARTED", "STATUS")
+    for (entry, status) in rows
         _print_row(
             out,
             string(entry.port),
@@ -281,12 +304,17 @@ function _list_servers(out::IO = stdout)
             entry.julia,
             entry.pid,
             entry.started,
+            _format_status(status),
         )
     end
     return nothing
 end
 
-function _print_row(out, port, name, project, julia, pid, started)
+function _print_row(
+        out::IO, port::AbstractString, name::AbstractString, project::AbstractString,
+        julia::AbstractString, pid::AbstractString, started::AbstractString,
+        status::AbstractString,
+    )
     return println(
         out,
         rpad(port, 6),
@@ -299,7 +327,9 @@ function _print_row(out, port, name, project, julia, pid, started)
         "  ",
         rpad(pid, 7),
         "  ",
-        started,
+        rpad(started, 23),
+        "  ",
+        status,
     )
 end
 

--- a/src/client.jl
+++ b/src/client.jl
@@ -141,76 +141,62 @@ function _take_value(args, index, flag)
     return args[index], index
 end
 
-# Match a server selector (`--port`/`--project`/`--name`) at `index`, shared by the
-# eval and kill parsers. Returns the updated selectors, the advanced index, and
-# whether the flag matched, so each parser handles only its own extra flags.
-function _match_selector(args, index, port, project, name)
-    arg = args[index]
-    if startswith(arg, "--port=")
-        port = _parse_port(arg[(length("--port=") + 1):end])
-    elseif arg == "--port"
-        value, index = _take_value(args, index, "--port")
-        port = _parse_port(value)
-    elseif startswith(arg, "--project=")
-        project = arg[(length("--project=") + 1):end]
-    elseif arg == "--project"
-        project, index = _take_value(args, index, "--project")
-    elseif startswith(arg, "--name=")
-        name = arg[(length("--name=") + 1):end]
-    elseif arg == "--name"
-        name, index = _take_value(args, index, "--name")
-    else
-        return port, project, name, index, false
+# Flags that carry a value, as `--flag value` or `--flag=value`. `-e`/`--eval` are
+# aliases for the code to run.
+const VALUED_FLAGS = ("--port", "--project", "--name", "--timeout", "-e", "--eval")
+# Flags that stand alone. `-f` is an alias for `--force`.
+const BARE_FLAGS = ("--force", "-f")
+
+# The valued flag `arg` names, whether written `--flag` or `--flag=value`, else
+# nothing. Centralizes the dual-form match so each flag is handled in one place.
+function _valued_flag(arg)
+    for flag in VALUED_FLAGS
+        (arg == flag || startswith(arg, flag * "=")) && return flag
     end
-    return port, project, name, index, true
+    return nothing
 end
 
-function _parse_client_args(args)
-    port = -1
-    project = ""
-    name = ""
-    code = nothing
-    timeout = nothing
+# Split args into a flag-to-value map and the set of bare flags present, accepting
+# both `--flag value` and `--flag=value`. Unknown arguments error.
+function _tokenize_args(args)
+    values = Dict{String, String}()
+    bare = Set{String}()
     index = 1
     while index <= length(args)
-        port, project, name, index, matched = _match_selector(args, index, port, project, name)
-        if !matched
-            arg = args[index]
-            if startswith(arg, "--timeout=")
-                timeout = _parse_timeout(arg[(length("--timeout=") + 1):end])
-            elseif arg == "--timeout"
-                value, index = _take_value(args, index, "--timeout")
-                timeout = _parse_timeout(value)
-            elseif arg == "-e" || arg == "--eval"
-                code, index = _take_value(args, index, "-e")
+        arg = args[index]
+        flag = _valued_flag(arg)
+        if !isnothing(flag)
+            if arg == flag
+                value, index = _take_value(args, index, flag)
+                values[flag] = value
             else
-                error("unrecognized argument: $arg")
+                values[flag] = arg[(length(flag) + 2):end]
             end
+        elseif arg in BARE_FLAGS
+            push!(bare, arg)
+        else
+            error("unrecognized argument: $arg")
         end
         index += 1
     end
-    return (; port, project, name, code, timeout)
+    return values, bare
 end
 
-function _parse_kill_args(args)
-    port = -1
-    project = ""
-    name = ""
-    force = false
-    index = 1
-    while index <= length(args)
-        port, project, name, index, matched = _match_selector(args, index, port, project, name)
-        if !matched
-            arg = args[index]
-            if arg == "--force" || arg == "-f"
-                force = true
-            else
-                error("unrecognized argument: $arg")
-            end
-        end
-        index += 1
-    end
-    return (; port, project, name, force)
+# Parse the client's arguments into selectors plus the per-mode flags. One parser
+# serves both paths: eval reads `code`/`timeout`, kill reads `force`. A flag for the
+# other mode is harmless: each caller reads only the fields it acts on.
+function _parse_args(args)
+    values, bare = _tokenize_args(args)
+    port = haskey(values, "--port") ? _parse_port(values["--port"]) : -1
+    timeout = haskey(values, "--timeout") ? _parse_timeout(values["--timeout"]) : nothing
+    return (;
+        port,
+        project = get(values, "--project", ""),
+        name = get(values, "--name", ""),
+        code = get(values, "-e", get(values, "--eval", nothing)),
+        timeout,
+        force = !isempty(bare),
+    )
 end
 
 function _parse_port(value::AbstractString)
@@ -337,7 +323,7 @@ end
 # server still resolves, sends SIGTERM (SIGKILL with --force), and removes the
 # registry entry, since a SIGKILL skips the server's own cleanup.
 function _kill_server(args; out::IO = stdout)
-    parsed = _parse_kill_args(args)
+    parsed = _parse_args(args)
     entry = _kill_target(parsed.port, parsed.project, parsed.name)
     pid = tryparse(Int, entry.pid)
     isnothing(pid) && error("registry entry for port $(entry.port) has no valid pid")
@@ -374,7 +360,7 @@ function cli(args = ARGS; out::IO = stdout, err::IO = stderr)
         if !isempty(args) && args[1] == "kill"
             return _kill_server(args[2:end]; out)
         end
-        parsed = _parse_client_args(args)
+        parsed = _parse_args(args)
         code = isnothing(parsed.code) ? read(stdin, String) : parsed.code
         target = _resolve_port(parsed.port, parsed.project, parsed.name)
         return _send(target, code; out, err, timeout_seconds = parsed.timeout)

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -10,7 +10,7 @@ PrecompileTools.@setup_workload begin
     ]
     PrecompileTools.@compile_workload begin
         for sample in arg_samples
-            _parse_client_args(sample)
+            _parse_args(sample)
         end
         # Exercise the registry and socket paths against a throwaway loopback
         # server so the framing, ping, and selection code specialize. Guarded so

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -40,23 +40,33 @@ const RESPONSE_PONG = 0x03
 const REQUEST_TYPES = (REQUEST_EVAL, REQUEST_PING)
 const RESPONSE_TYPES = (RESPONSE_OK, RESPONSE_ERR, RESPONSE_PONG)
 
+# A read that outlived its bound. Carries the bound so callers can phrase their own
+# message; `showerror` keeps the wire-facing text servers reply to clients with.
+struct ReadTimeout <: Exception
+    timeout_seconds::Float64
+end
+Base.showerror(io::IO, err::ReadTimeout) =
+    print(io, "Read timeout: no data received within $(err.timeout_seconds) seconds")
+
 # Run a blocking read on `sock`, closing the socket if it outlives the timeout so
 # the read unblocks with an IOError instead of hanging. The caller closes `sock`
-# again in its own `finally`; the second close is a no-op.
+# again in its own `finally`; the second close is a no-op. A `nothing` timeout
+# blocks with no bound, for callers that must wait as long as the work takes.
 function _read_with_timeout(thunk, sock; timeout_seconds = READ_TIMEOUT_SECONDS)
+    isnothing(timeout_seconds) && return thunk()
     timed_out = Ref(false)
     timer = Timer(timeout_seconds) do _
         timed_out[] = true
         close(sock)
     end
     return try
-        thunk()
+        # Closing the socket may unblock the read by returning short/empty rather
+        # than throwing, so the timeout is detected from the flag, not the throw.
+        result = thunk()
+        timed_out[] && throw(ReadTimeout(timeout_seconds))
+        result
     catch
-        timed_out[] && throw(
-            ErrorException(
-                "Read timeout: no data received within $(timeout_seconds) seconds",
-            ),
-        )
+        timed_out[] && throw(ReadTimeout(timeout_seconds))
         rethrow()
     finally
         close(timer)

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -88,7 +88,9 @@ _ping(port::Integer; timeout_seconds = PING_TIMEOUT_SECONDS) =
     !isnothing(_ping_status(port; timeout_seconds))
 
 # Signals for terminating a server process. SIGTERM asks; SIGKILL forces and is
-# the only stop that lands on a worker wedged in a tight, non-yielding loop.
+# the only stop that lands on a worker wedged in a tight, non-yielding loop. libuv
+# maps both, plus the signal-0 existence check, onto Windows, so the kill path is
+# cross-platform.
 const SIGTERM = 15
 const SIGKILL = 9
 
@@ -97,10 +99,10 @@ const SIGKILL = 9
 # is a live process that cannot pong, so this is how `kill` finds its target.
 _process_alive(pid::Integer) = _signal_process(pid, 0)
 
-# Send `signal` to `pid`. Returns true when delivered, false when the process is
-# already gone (the `kill` syscall reports ESRCH).
+# Send `signal` to `pid` through libuv. Returns true when delivered, false when the
+# process is already gone (`uv_kill` reports a negative UV error such as ESRCH).
 _signal_process(pid::Integer, signal::Integer) =
-    ccall(:kill, Cint, (Cint, Cint), pid, signal) == 0
+    ccall(:uv_kill, Cint, (Cint, Cint), pid, signal) == 0
 
 # Drop registry entries for this project whose servers no longer answer a ping.
 # Replaces the old per-project lock: several live servers per project coexist.

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -63,23 +63,29 @@ function _write_registry_entry(
     return path
 end
 
-# Probe a server with a ping frame, expecting a pong. A different-version server
-# fails the version check and reads as dead, which is the intended lockstep
-# behavior. Matches the liveness check the CLI uses for `ls`.
-function _ping(port::Integer; timeout_seconds = PING_TIMEOUT_SECONDS)
+# Probe a server with a ping frame. Returns the pong body (a busy-since marker,
+# empty when idle) when the server answers, or `nothing` when it does not. A
+# different-version server fails the version check and reads as dead, which is the
+# intended lockstep behavior.
+function _ping_status(port::Integer; timeout_seconds = PING_TIMEOUT_SECONDS)
     try
         sock = Sockets.connect(Sockets.localhost, port)
         try
             _write_frame(sock, REQUEST_PING, "")
             frame = _read_frame(sock, RESPONSE_TYPES; timeout_seconds)
-            return !isnothing(frame) && frame.type == RESPONSE_PONG
+            (isnothing(frame) || frame.type != RESPONSE_PONG) && return nothing
+            return frame.body
         finally
             close(sock)
         end
     catch
-        return false
+        return nothing
     end
 end
+
+# Liveness as a boolean, for prune and resolution. Matches the check `ls` uses.
+_ping(port::Integer; timeout_seconds = PING_TIMEOUT_SECONDS) =
+    !isnothing(_ping_status(port; timeout_seconds))
 
 # Signals for terminating a server process. SIGTERM asks; SIGKILL forces and is
 # the only stop that lands on a worker wedged in a tight, non-yielding loop.

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -81,6 +81,21 @@ function _ping(port::Integer; timeout_seconds = PING_TIMEOUT_SECONDS)
     end
 end
 
+# Signals for terminating a server process. SIGTERM asks; SIGKILL forces and is
+# the only stop that lands on a worker wedged in a tight, non-yielding loop.
+const SIGTERM = 15
+const SIGKILL = 9
+
+# Liveness by process existence, independent of whether the server answers its
+# socket. Signal 0 delivers nothing but still checks the target: a wedged server
+# is a live process that cannot pong, so this is how `kill` finds its target.
+_process_alive(pid::Integer) = _signal_process(pid, 0)
+
+# Send `signal` to `pid`. Returns true when delivered, false when the process is
+# already gone (the `kill` syscall reports ESRCH).
+_signal_process(pid::Integer, signal::Integer) =
+    ccall(:kill, Cint, (Cint, Cint), pid, signal) == 0
+
 # Drop registry entries for this project whose servers no longer answer a ping.
 # Replaces the old per-project lock: several live servers per project coexist.
 function _prune_dead_entries(project::AbstractString)

--- a/src/server.jl
+++ b/src/server.jl
@@ -22,8 +22,9 @@ evaluates code from clients until closed.
 Each message is a frame: a 10-byte header (`"REPL"` magic, a version byte, a type
 byte, then a big-endian `UInt32` body length) followed by the body. Requests are
 `eval` (body is code) or `ping`; responses are `ok`/`err` (body is the result or
-error text) or `pong`. Every frame is validated for magic, version, type, and a
-16 MB length cap before its body is trusted.
+error text) or `pong` (body is the worker's busy-since timestamp, empty when
+idle). Every frame is validated for magic, version, type, and a 16 MB length cap
+before its body is trusted.
 
 # Example
 ```julia
@@ -50,6 +51,9 @@ mutable struct Server
     project::Union{String, Nothing}
     started::Union{Dates.DateTime, Nothing}
     name::String
+    # When the worker is mid-evaluation, the time it started; `nothing` when idle.
+    # Written only by the single worker task, read by ping responders for `ls`.
+    busy_since::Union{Dates.DateTime, Nothing}
 
     function Server(
             mod = nothing;
@@ -69,6 +73,7 @@ mutable struct Server
         srv.project = nothing
         srv.started = nothing
         srv.name = ""
+        srv.busy_since = nothing
         srv.task = errormonitor(@async _server(srv))
         # Tie the channel's lifetime to the task so a startup failure closes the
         # channel and surfaces the error to `take!` instead of blocking forever.
@@ -234,6 +239,7 @@ function _spawn_worker(request_queue, active_connections, srv::Server)
         Threads.@spawn begin
             try
                 for request in request_queue
+                    srv.busy_since = Dates.now()
                     try
                         _revise(
                             _handle_eval,
@@ -244,6 +250,7 @@ function _spawn_worker(request_queue, active_connections, srv::Server)
                             srv.verbose,
                         )
                     finally
+                        srv.busy_since = nothing
                         # Always decrement counter when done with a connection
                         Threads.atomic_sub!(active_connections, 1)
                     end
@@ -293,6 +300,10 @@ function _admit(
     return
 end
 
+# The pong body: the worker's busy-since timestamp, or empty when idle. Clients
+# render it in `ls` to tell a wedged server from an idle one.
+_busy_marker(srv::Server) = isnothing(srv.busy_since) ? "" : string(srv.busy_since)
+
 # Per-connection dispatcher. Reads one frame, answers a ping immediately so
 # liveness never queues behind an evaluation, and hands an eval to the worker.
 # Pings, framing errors, and bare disconnects release the connection here; the
@@ -307,7 +318,7 @@ function _dispatch(
         if isnothing(frame)
             return  # bare disconnect, nothing to reply to
         elseif frame.type == REQUEST_PING
-            _write_frame(sock, RESPONSE_PONG, "")
+            _write_frame(sock, RESPONSE_PONG, _busy_marker(srv))
             srv.verbose && @info "Answered ping" id
         else
             put!(request_queue, ClientRequest(sock, id, frame.body))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"

--- a/test/cli_tests.jl
+++ b/test/cli_tests.jl
@@ -60,6 +60,46 @@ end
     end
 end
 
+@testitem "status_formatting" tags = [:cli] begin
+    import REPLicant
+    import Dates
+
+    # An empty pong body is an idle server.
+    @test REPLicant._format_status("") == "idle"
+
+    # A timestamp marks a busy server, rendered with elapsed seconds.
+    marker = string(Dates.now() - Dates.Second(5))
+    rendered = REPLicant._format_status(marker)
+    @test contains(rendered, "busy")
+    @test contains(rendered, "s")
+
+    # A garbled marker still reads as busy rather than crashing.
+    @test contains(REPLicant._format_status("not-a-date"), "busy")
+end
+
+@testitem "ls_reports_busy_state" tags = [:cli] setup = [Utilities] begin
+    import REPLicant
+
+    Utilities.withserver() do server, mod, port
+        # An idle server: empty pong body, STATUS column shows idle.
+        @test REPLicant._ping_status(port) == ""
+        out = IOBuffer()
+        @test REPLicant.cli(["ls"]; out) == 0
+        listing = String(take!(out))
+        @test contains(listing, "STATUS")
+        @test contains(listing, "idle")
+
+        # Occupy the worker; the pong now carries a busy-since marker and ls
+        # renders the server busy.
+        busy = @async Utilities.request(port, "sleep(2)")
+        sleep(0.5)
+        @test !isempty(REPLicant._ping_status(port))
+        @test REPLicant.cli(["ls"]; out) == 0
+        @test contains(String(take!(out)), "busy")
+        wait(busy)
+    end
+end
+
 @testitem "client_send_and_ls" tags = [:cli] setup = [Utilities] begin
     import REPLicant
 

--- a/test/cli_tests.jl
+++ b/test/cli_tests.jl
@@ -24,6 +24,42 @@
     @test_throws Exception REPLicant._parse_client_args(["--bogus"])
 end
 
+@testitem "client_timeout_parsing" tags = [:cli] begin
+    import REPLicant
+
+    # No --timeout means no bound: the client waits as long as the eval runs.
+    @test isnothing(REPLicant._parse_client_args(["-e", "1"]).timeout)
+
+    @test REPLicant._parse_client_args(["--timeout=2.5", "-e", "1"]).timeout == 2.5
+    @test REPLicant._parse_client_args(["--timeout", "3", "-e", "1"]).timeout == 3.0
+
+    @test_throws Exception REPLicant._parse_client_args(["--timeout=abc"])
+    @test_throws Exception REPLicant._parse_client_args(["--timeout=0"])
+    @test_throws Exception REPLicant._parse_client_args(["--timeout=-1"])
+    @test_throws Exception REPLicant._parse_client_args(["--timeout"])
+end
+
+@testitem "client_timeout_frees_caller" tags = [:cli] setup = [Utilities] begin
+    import REPLicant
+
+    Utilities.withserver() do server, mod, port
+        out = IOBuffer()
+        err = IOBuffer()
+        # A non-returning eval holds the worker; --timeout frees the caller without
+        # waiting for a response.
+        elapsed = @elapsed code =
+            REPLicant.cli(["--port=$port", "--timeout=0.5", "-e", "sleep(3)"]; out, err)
+        @test code == 1
+        @test elapsed < 2
+        @test isempty(String(take!(out)))
+        # The error names the timeout and points at kill as the recovery.
+        message = String(take!(err))
+        @test contains(message, "kill")
+        # The server is still alive: pings are answered off the wedged worker.
+        @test REPLicant._ping(port)
+    end
+end
+
 @testitem "client_send_and_ls" tags = [:cli] setup = [Utilities] begin
     import REPLicant
 

--- a/test/cli_tests.jl
+++ b/test/cli_tests.jl
@@ -1,42 +1,42 @@
 @testitem "client_arg_parsing" tags = [:cli] begin
     import REPLicant
 
-    basic = REPLicant._parse_client_args(["--port=8000", "-e", "x"])
+    basic = REPLicant._parse_args(["--port=8000", "-e", "x"])
     @test basic.port == 8000
     @test basic.code == "x"
     @test basic.project == ""
     @test basic.name == ""
 
     spaced =
-        REPLicant._parse_client_args(["--port", "8001", "--project", "p", "--name", "n"])
+        REPLicant._parse_args(["--port", "8001", "--project", "p", "--name", "n"])
     @test spaced.port == 8001
     @test spaced.project == "p"
     @test spaced.name == "n"
     @test isnothing(spaced.code)
 
-    joined = REPLicant._parse_client_args(["--project=/tmp/x", "--name=lbl", "--eval", "1"])
+    joined = REPLicant._parse_args(["--project=/tmp/x", "--name=lbl", "--eval", "1"])
     @test joined.project == "/tmp/x"
     @test joined.name == "lbl"
     @test joined.code == "1"
 
-    @test_throws Exception REPLicant._parse_client_args(["--port=abc"])
-    @test_throws Exception REPLicant._parse_client_args(["--port"])
-    @test_throws Exception REPLicant._parse_client_args(["--bogus"])
+    @test_throws Exception REPLicant._parse_args(["--port=abc"])
+    @test_throws Exception REPLicant._parse_args(["--port"])
+    @test_throws Exception REPLicant._parse_args(["--bogus"])
 end
 
 @testitem "client_timeout_parsing" tags = [:cli] begin
     import REPLicant
 
     # No --timeout means no bound: the client waits as long as the eval runs.
-    @test isnothing(REPLicant._parse_client_args(["-e", "1"]).timeout)
+    @test isnothing(REPLicant._parse_args(["-e", "1"]).timeout)
 
-    @test REPLicant._parse_client_args(["--timeout=2.5", "-e", "1"]).timeout == 2.5
-    @test REPLicant._parse_client_args(["--timeout", "3", "-e", "1"]).timeout == 3.0
+    @test REPLicant._parse_args(["--timeout=2.5", "-e", "1"]).timeout == 2.5
+    @test REPLicant._parse_args(["--timeout", "3", "-e", "1"]).timeout == 3.0
 
-    @test_throws Exception REPLicant._parse_client_args(["--timeout=abc"])
-    @test_throws Exception REPLicant._parse_client_args(["--timeout=0"])
-    @test_throws Exception REPLicant._parse_client_args(["--timeout=-1"])
-    @test_throws Exception REPLicant._parse_client_args(["--timeout"])
+    @test_throws Exception REPLicant._parse_args(["--timeout=abc"])
+    @test_throws Exception REPLicant._parse_args(["--timeout=0"])
+    @test_throws Exception REPLicant._parse_args(["--timeout=-1"])
+    @test_throws Exception REPLicant._parse_args(["--timeout"])
 end
 
 @testitem "client_timeout_frees_caller" tags = [:cli] setup = [Utilities] begin

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -23,8 +23,8 @@
         # reader. Help mode's `@doc` fallback `show`s a docs object of unknown
         # type. The `kill` and `--timeout` paths add socket-IO and `println`-over-
         # `IO` reports in the same category. Threading stays inferrable: opt is 0.
-        SOUND_LIMIT = 353   # JET.report_package(REPLicant; mode = :sound)
-        OPT_LIMIT = 0       # JET.report_opt on _parse_client_args(::Vector{String})
+        SOUND_LIMIT = 316   # JET.report_package(REPLicant; mode = :sound)
+        OPT_LIMIT = 0       # JET.report_opt on _parse_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)
             sound = JET.get_reports(
@@ -36,7 +36,7 @@
 
             opt = JET.get_reports(
                 JET.report_opt(
-                    Tuple{typeof(REPLicant._parse_client_args), Vector{String}};
+                    Tuple{typeof(REPLicant._parse_args), Vector{String}};
                     target_modules = (REPLicant,),
                 ),
             )

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -16,15 +16,14 @@
         # the Julia and JET versions (JET 0.10 on Julia 1.12), so the ratchet runs
         # only there.
         JET_JULIA = v"1.12"
-        # Help mode's `@doc` fallback evaluates and `show`s a docs object of
-        # unknown type, so `_help`/`__help`/`_render_md` contribute intentional
-        # dynamic-dispatch reports over `Any`; the rest are socket IO and logging.
-        # +5 over the prior 308: the output `Router`/`RouterDisplay` write to an
-        # abstract `IO` resolved per task, and `_capture`'s pipe reader,
-        # `flush_cstdio`, and RNG copy/restore add more reports over the pipe's
-        # abstract IO, so JET sees intentional dynamic dispatch on `write`/`show`,
-        # like the socket IO paths.
-        SOUND_LIMIT = 313   # JET.report_package(REPLicant; mode = :sound)
+        # The count is intentional dynamic dispatch: eval over `Any`, sound-mode
+        # `getfield`/`setfield` on the `cli`/parser NamedTuples and the server's
+        # `busy_since`, and abstract-IO `write`/`show` across the socket paths, the
+        # per-task output `Router`, the `ls` status table, and `_capture`'s pipe
+        # reader. Help mode's `@doc` fallback `show`s a docs object of unknown
+        # type. The `kill` and `--timeout` paths add socket-IO and `println`-over-
+        # `IO` reports in the same category. Threading stays inferrable: opt is 0.
+        SOUND_LIMIT = 353   # JET.report_package(REPLicant; mode = :sound)
         OPT_LIMIT = 0       # JET.report_opt on _parse_client_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)

--- a/test/kill_tests.jl
+++ b/test/kill_tests.jl
@@ -17,8 +17,9 @@ end
 @testitem "process_liveness_and_signal" tags = [:kill] begin
     import REPLicant
 
-    # A real child process: alive before the signal, gone after.
-    proc = run(`sleep 30`; wait = false)
+    # A real child process: alive before the signal, gone after. A Julia
+    # subprocess sleeps, so the test does not depend on a platform `sleep` binary.
+    proc = run(`$(Base.julia_cmd()) --startup-file=no -e "sleep(30)"`; wait = false)
     pid = Base.process_running(proc) ? getpid(proc) : error("child did not start")
     @test REPLicant._process_alive(pid)
 

--- a/test/kill_tests.jl
+++ b/test/kill_tests.jl
@@ -1,17 +1,17 @@
 @testitem "kill_args_parsing" tags = [:kill] begin
     import REPLicant
 
-    bare = REPLicant._parse_kill_args(["--port=8000"])
+    bare = REPLicant._parse_args(["--port=8000"])
     @test bare.port == 8000
     @test bare.force == false
 
-    spaced = REPLicant._parse_kill_args(["--name", "n", "--project", "p", "--force"])
+    spaced = REPLicant._parse_args(["--name", "n", "--project", "p", "--force"])
     @test spaced.name == "n"
     @test spaced.project == "p"
     @test spaced.force == true
 
-    @test REPLicant._parse_kill_args(["-f"]).force == true
-    @test_throws Exception REPLicant._parse_kill_args(["--bogus"])
+    @test REPLicant._parse_args(["-f"]).force == true
+    @test_throws Exception REPLicant._parse_args(["--bogus"])
 end
 
 @testitem "process_liveness_and_signal" tags = [:kill] begin

--- a/test/kill_tests.jl
+++ b/test/kill_tests.jl
@@ -1,0 +1,87 @@
+@testitem "kill_args_parsing" tags = [:kill] begin
+    import REPLicant
+
+    bare = REPLicant._parse_kill_args(["--port=8000"])
+    @test bare.port == 8000
+    @test bare.force == false
+
+    spaced = REPLicant._parse_kill_args(["--name", "n", "--project", "p", "--force"])
+    @test spaced.name == "n"
+    @test spaced.project == "p"
+    @test spaced.force == true
+
+    @test REPLicant._parse_kill_args(["-f"]).force == true
+    @test_throws Exception REPLicant._parse_kill_args(["--bogus"])
+end
+
+@testitem "process_liveness_and_signal" tags = [:kill] begin
+    import REPLicant
+
+    # A real child process: alive before the signal, gone after.
+    proc = run(`sleep 30`; wait = false)
+    pid = Base.process_running(proc) ? getpid(proc) : error("child did not start")
+    @test REPLicant._process_alive(pid)
+
+    @test REPLicant._signal_process(pid, REPLicant.SIGKILL)
+    wait(proc)
+    @test !REPLicant._process_alive(pid)
+
+    # Signalling a pid that is already gone reports not-delivered, never throws.
+    @test REPLicant._signal_process(pid, REPLicant.SIGTERM) == false
+end
+
+@testitem "kill_target_selection" tags = [:kill] begin
+    import REPLicant
+
+    # Raw registry resolution: no ping, so a wedged server still resolves. Write
+    # entries with arbitrary pids and assert the cascade picks the right one.
+    mktempdir() do registry
+        withenv("REPLICANT_DIR" => registry) do
+            REPLicant._write_registry_entry(9001, "/work/a"; name = "alpha")
+            REPLicant._write_registry_entry(9002, "/work/b"; name = "beta")
+
+            @test REPLicant._kill_target(9001, "", "").port == 9001
+            @test REPLicant._kill_target(-1, "", "beta").port == 9002
+
+            # An unregistered port has nothing to kill.
+            @test_throws Exception REPLicant._kill_target(9999, "", "")
+            # Two servers, no selector: ambiguous.
+            @test_throws Exception REPLicant._kill_target(-1, "", "")
+            # Unknown name.
+            @test_throws Exception REPLicant._kill_target(-1, "", "missing")
+        end
+    end
+end
+
+@testitem "kill_terminates_wedged_server" tags = [:kill] setup = [Utilities] begin
+    import REPLicant
+    import Sockets
+
+    mktempdir() do registry
+        mktempdir() do work
+            entry_path = Utilities.spawn_server(registry, work) do port, pid
+                # Wedge the worker on a non-returning eval: fire the frame and do
+                # not wait for a response that will never come.
+                wedge = Sockets.connect(Sockets.localhost, port)
+                REPLicant._write_frame(wedge, REPLicant.REQUEST_EVAL, "while true; end")
+                sleep(0.5)
+
+                out = IOBuffer()
+                withenv("REPLICANT_DIR" => registry) do
+                    # Kill resolves and terminates without needing a pong.
+                    @test REPLicant._kill_server(["--port=$port", "--force"]; out) == 0
+                end
+                @test contains(String(take!(out)), string(pid))
+
+                # The process dies and its registry entry is removed.
+                deadline = time() + 10
+                while REPLicant._process_alive(pid) && time() < deadline
+                    sleep(0.1)
+                end
+                @test !REPLicant._process_alive(pid)
+                close(wedge)
+            end
+            @test !isfile(entry_path)
+        end
+    end
+end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -118,7 +118,12 @@
     function _wait_for_entry(registry; timeout = 60)
         deadline = time() + timeout
         while time() < deadline
-            files = filter(f -> isfile(joinpath(registry, f)), readdir(registry))
+            # Match only the final entry, named by port digits. The atomic write
+            # briefly leaves a `<port>.tmp.<pid>` file; skip it so the reader never
+            # sees a half-written entry.
+            files = filter(readdir(registry)) do f
+                isfile(joinpath(registry, f)) && all(isdigit, f)
+            end
             isempty(files) || return joinpath(registry, first(files))
             sleep(0.1)
         end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -89,6 +89,42 @@
         end
     end
 
+    # Launch a REPLicant server in a separate Julia process registered in
+    # `registry`, rooted at `work`. Waits for its registry entry, then runs
+    # `func(port, pid)` against the live process. The subprocess is killed on exit;
+    # returns the entry path so a test can assert it was cleaned up. Used by kill
+    # tests, which must target a process other than the test runner.
+    function spawn_server(func, registry, work)
+        script = "using REPLicant; s = REPLicant.Server(); take!(s.channel); wait(s.task)"
+        project = pkgdir(REPLicant)
+        env = copy(ENV)
+        env["REPLICANT_DIR"] = registry
+        cmd = setenv(
+            `$(Base.julia_cmd()) --project=$project --startup-file=no -e $script`,
+            env;
+            dir = work,
+        )
+        proc = run(pipeline(cmd; stdout = devnull, stderr = devnull); wait = false)
+        return try
+            entry_path = _wait_for_entry(registry)
+            fields = REPLicant._parse_registry_entry(entry_path)
+            func(parse(Int, fields["port"]), parse(Int, fields["pid"]))
+            entry_path
+        finally
+            process_running(proc) && kill(proc, Base.SIGKILL)
+        end
+    end
+
+    function _wait_for_entry(registry; timeout = 60)
+        deadline = time() + timeout
+        while time() < deadline
+            files = filter(f -> isfile(joinpath(registry, f)), readdir(registry))
+            isempty(files) || return joinpath(registry, first(files))
+            sleep(0.1)
+        end
+        return error("server did not register within $(timeout)s")
+    end
+
     # Run `func(start, registry)` inside an isolated project and registry, where
     # `start()` launches another server in that same project and returns
     # `(server, port)`. Lets a test stand up several servers in one project to


### PR DESCRIPTION
A single eval that never returns (`while true`, a deadlock, a blocking read) holds the server's one sequential worker forever: the caller blocks on the response, later evals queue behind it, and the server still answers pings so it looks alive. Julia cannot interrupt a running task (a task interrupt only lands at a yield point, never in a tight loop), so the recovery is to kill the process. This adds three independent pieces to detect, escape, and recover from that state.

- **`--timeout <seconds>`** bounds the client's wait. On expiry it exits non-zero and points at `julia +rpc kill`. Without the flag the client waits as long as the eval runs, which also fixes a latent bug: the response read had been inheriting the 30s request timeout, so any eval longer than 30s lost its result.
- **`julia +rpc kill [--force]`** terminates the target's process: SIGTERM by default, SIGKILL with `--force` (the only signal that lands on a tight loop). It resolves from the raw registry without a ping, so a wedged server that cannot pong still resolves, and removes the registry entry since a SIGKILL skips the server's own cleanup.
- **`ls` gains a `STATUS` column** (`idle` / `busy <n>s`), carried in the pong body, so a wedged server is visible without a separate probe.

The selection cascade is factored into `_select_entry`, shared by eval (pinged) and kill (raw registry) resolution; the `--port`/`--project`/`--name` flag parsing is shared via `_match_selector`. The JET sound ratchet moves to 353 (intentional socket-IO and NamedTuple dispatch), opt analyzer still 0.