### PR TITLE
feat(client): add interrupt to free a wedged eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `julia +rpc interrupt` to free a server wedged on a running eval without killing it: the request schedules an `InterruptException` onto the running evaluation, answered off the worker queue so it reaches a busy server, leaving the session and its loaded state intact. The worker runs each eval in its own task, so the interrupt frees that eval alone and the server keeps serving. Delivery is cooperative, so a tight non-yielding loop still needs `kill`; `interrupt` is the soft recovery tier [#39]
 - Show evaluation state in `julia +rpc ls`: a `STATUS` column reads `idle`, or `busy <n>s` while the server is mid-evaluation, carried in the pong body so a wedged server is visible without a separate probe [#38]
 - Add `julia +rpc kill [--force]` to terminate a server whose worker is wedged on a non-returning eval. The target resolves from the raw registry (no ping), so a server that cannot answer its socket still resolves; `kill` sends SIGTERM, `--force` sends SIGKILL, the only signal that lands on a tight non-yielding loop. Julia cannot interrupt a running task, so killing the process is the recovery [#38]
 - Bound the client's wait for a result with `--timeout <seconds>`: an eval that does not respond in time frees the caller with a non-zero exit and a message pointing at `julia +rpc kill`, instead of stalling on a wedged server. Without the flag the client waits as long as the eval runs [#38]
@@ -84,3 +85,4 @@ Initial Public Release
 [#35]: https://github.com/MichaelHatherly/REPLicant.jl/issues/35
 [#36]: https://github.com/MichaelHatherly/REPLicant.jl/issues/36
 [#38]: https://github.com/MichaelHatherly/REPLicant.jl/issues/38
+[#39]: https://github.com/MichaelHatherly/REPLicant.jl/issues/39

--- a/src/client.jl
+++ b/src/client.jl
@@ -135,7 +135,7 @@ end
 
 # Consume the value following a flag at `index`, erroring when the flag ends the
 # argument list. Returns the value and the advanced index.
-function _take_value(args, index, flag)
+function _take_value(args::Vector{String}, index, flag)
     index += 1
     index > length(args) && error("$flag needs a value")
     return args[index], index
@@ -158,7 +158,7 @@ end
 
 # Split args into a flag-to-value map and the set of bare flags present, accepting
 # both `--flag value` and `--flag=value`. Unknown arguments error.
-function _tokenize_args(args)
+function _tokenize_args(args::Vector{String})
     values = Dict{String, String}()
     bare = Set{String}()
     index = 1
@@ -185,7 +185,7 @@ end
 # Parse the client's arguments into selectors plus the per-mode flags. One parser
 # serves both paths: eval reads `code`/`timeout`, kill reads `force`. A flag for the
 # other mode is harmless: each caller reads only the fields it acts on.
-function _parse_args(args)
+function _parse_args(args::Vector{String})
     values, bare = _tokenize_args(args)
     port = haskey(values, "--port") ? _parse_port(values["--port"]) : -1
     timeout = haskey(values, "--timeout") ? _parse_timeout(values["--timeout"]) : nothing
@@ -322,7 +322,7 @@ end
 # Terminate a target server's process. Resolves from the raw registry so a wedged
 # server still resolves, sends SIGTERM (SIGKILL with --force), and removes the
 # registry entry, since a SIGKILL skips the server's own cleanup.
-function _kill_server(args; out::IO = stdout)
+function _kill_server(args::Vector{String}; out::IO = stdout)
     parsed = _parse_args(args)
     entry = _kill_target(parsed.port, parsed.project, parsed.name)
     pid = tryparse(Int, entry.pid)
@@ -342,16 +342,37 @@ function _kill_server(args; out::IO = stdout)
     return 0
 end
 
+# Free a server wedged on a running eval without killing the process. Resolves a
+# live server (the soft tier needs a healthy dispatcher to receive the request, so
+# live resolution gives a clean "no servers" error rather than a hang), schedules an
+# `InterruptException` onto the running eval, and reports the outcome.
+function _interrupt_server(args::Vector{String}; out::IO = stdout)
+    parsed = _parse_args(args)
+    target = _resolve_port(parsed.port, parsed.project, parsed.name)
+    sock = Sockets.connect(Sockets.localhost, target)
+    try
+        _write_frame(sock, REQUEST_INTERRUPT, "")
+        frame = _read_frame(sock, RESPONSE_TYPES; timeout_seconds = PING_TIMEOUT_SECONDS)
+        isnothing(frame) && error("server closed the connection without a response")
+        println(out, "REPLicant server on port $target: $(frame.body)")
+        return 0
+    finally
+        close(sock)
+    end
+end
+
 """
     cli(args = ARGS; out = stdout, err = stderr) -> Int
 
 Forwarding client entrypoint. A leading `ls`/`list` prints the live servers; a
-leading `kill` terminates a resolved server (`--force` for SIGKILL). Otherwise it
-resolves a target server and forwards code to it, taken from `-e` or, when absent,
-from stdin. `--timeout <seconds>` bounds the wait for a result. Returns a process
-exit code.
+leading `kill` terminates a resolved server (`--force` for SIGKILL); a leading
+`interrupt` frees a server wedged on a running eval, scheduling an
+`InterruptException` onto it without killing the process (`kill` stays the hard
+tier). Otherwise it resolves a target server and forwards code to it, taken from
+`-e` or, when absent, from stdin. `--timeout <seconds>` bounds the wait for a
+result. Returns a process exit code.
 """
-function cli(args = ARGS; out::IO = stdout, err::IO = stderr)
+function cli(args::Vector{String} = ARGS; out::IO = stdout, err::IO = stderr)
     try
         if !isempty(args) && (args[1] == "ls" || args[1] == "list")
             _list_servers(out)
@@ -359,6 +380,9 @@ function cli(args = ARGS; out::IO = stdout, err::IO = stderr)
         end
         if !isempty(args) && args[1] == "kill"
             return _kill_server(args[2:end]; out)
+        end
+        if !isempty(args) && args[1] == "interrupt"
+            return _interrupt_server(args[2:end]; out)
         end
         parsed = _parse_args(args)
         code = isnothing(parsed.code) ? read(stdin, String) : parsed.code

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -125,7 +125,13 @@ function _capture(f)
                 f(), false, Vector{Ptr{Cvoid}}()
             catch err
                 err isa InterruptException && rethrow()
-                err, true, catch_backtrace()
+                # `include_string` wraps an interrupt thrown in user code as a
+                # `LoadError`. Report it to the client like any error, but with no
+                # backtrace: the exception was delivered asynchronously at an
+                # arbitrary point, and walking that stack under threads deadlocks in
+                # the runtime's stack lookup.
+                interrupted = err isa LoadError && err.error isa InterruptException
+                err, true, (interrupted ? Ptr{Cvoid}[] : catch_backtrace())
             finally
                 # Drain libc's own stdio buffers into the pipe before restoring
                 # the fds, so fully-buffered C output (e.g. `puts`) is captured

--- a/src/protocol.jl
+++ b/src/protocol.jl
@@ -9,10 +9,10 @@
 #   length   UInt32 (BE)  4 bytes  body byte count
 #   body     length bytes          UTF-8
 #
-# Request types are `eval`/`ping`, response types `ok`/`err`/`pong`. The type code
-# is an open enum: new response codes (a serialized value, a MIME bundle) extend
-# the protocol without a format break. Every read validates magic, version, type,
-# and length before trusting the body.
+# Request types are `eval`/`ping`/`interrupt`, response types `ok`/`err`/`pong`.
+# The type code is an open enum: new response codes (a serialized value, a MIME
+# bundle) extend the protocol without a format break. Every read validates magic,
+# version, type, and length before trusting the body.
 #
 
 const READ_TIMEOUT_SECONDS = 30.0
@@ -33,11 +33,12 @@ const FRAME_HEADER_BYTES = length(PROTOCOL_MAGIC) + 6  # magic + version + type 
 
 const REQUEST_EVAL = 0x01
 const REQUEST_PING = 0x02
+const REQUEST_INTERRUPT = 0x03
 const RESPONSE_OK = 0x01
 const RESPONSE_ERR = 0x02
 const RESPONSE_PONG = 0x03
 
-const REQUEST_TYPES = (REQUEST_EVAL, REQUEST_PING)
+const REQUEST_TYPES = (REQUEST_EVAL, REQUEST_PING, REQUEST_INTERRUPT)
 const RESPONSE_TYPES = (RESPONSE_OK, RESPONSE_ERR, RESPONSE_PONG)
 
 # A read that outlived its bound. Carries the bound so callers can phrase their own

--- a/src/server.jl
+++ b/src/server.jl
@@ -21,10 +21,12 @@ evaluates code from clients until closed.
 # Protocol
 Each message is a frame: a 10-byte header (`"REPL"` magic, a version byte, a type
 byte, then a big-endian `UInt32` body length) followed by the body. Requests are
-`eval` (body is code) or `ping`; responses are `ok`/`err` (body is the result or
-error text) or `pong` (body is the worker's busy-since timestamp, empty when
-idle). Every frame is validated for magic, version, type, and a 16 MB length cap
-before its body is trusted.
+`eval` (body is code), `ping`, or `interrupt`; responses are `ok`/`err` (body is the
+result or error text) or `pong` (body is the worker's busy-since timestamp, empty
+when idle). An `interrupt` schedules an `InterruptException` onto the running eval (a
+no-op when idle) and is answered off the worker queue, like `ping`, so it reaches a
+wedged server. Every frame is validated for magic, version, type, and a 16 MB length
+cap before its body is trusted.
 
 # Example
 ```julia
@@ -54,6 +56,12 @@ mutable struct Server
     # When the worker is mid-evaluation, the time it started; `nothing` when idle.
     # Written only by the single worker task, read by ping responders for `ls`.
     busy_since::Union{Dates.DateTime, Nothing}
+    # Notified to request an interrupt of the eval in flight; `nothing` when idle.
+    # The dispatcher notifies it off the worker queue; a watcher pinned to the
+    # eval's thread answers, scheduling the `InterruptException` only while the eval
+    # is parked. Same-thread delivery is the only safe way to throw into a
+    # cooperatively-running task. Written by the worker, read by the dispatcher.
+    interrupt_signal::Union{Base.Event, Nothing}
 
     function Server(
             mod = nothing;
@@ -74,6 +82,7 @@ mutable struct Server
         srv.started = nothing
         srv.name = ""
         srv.busy_since = nothing
+        srv.interrupt_signal = nothing
         srv.task = errormonitor(@async _server(srv))
         # Tie the channel's lifetime to the task so a startup failure closes the
         # channel and surfaces the error to `take!` instead of blocking forever.
@@ -239,18 +248,51 @@ function _spawn_worker(request_queue, active_connections, srv::Server)
         Threads.@spawn begin
             try
                 for request in request_queue
+                    # Run the eval in its own task so an interrupt request frees it
+                    # without unwinding the worker loop. The worker stays sequential:
+                    # it waits for each eval before taking the next, so only one eval
+                    # task, and one output capture, exists at a time. The task is
+                    # sticky (`@async`, not `Threads.@spawn`): the watcher below
+                    # schedules the interrupt from this same thread, so the eval must
+                    # stay pinned to it.
+                    eval_task = @async _revise(
+                        _handle_eval,
+                        request.socket,
+                        request.id,
+                        request.code,
+                        srv.mod,
+                        srv.verbose,
+                    )
+                    # Deliver an interrupt on the eval's own thread. Pinned there by
+                    # `@async`, the watcher runs only when the eval has yielded, so
+                    # `schedule` lands on a parked task, the only safe way to throw an
+                    # exception into a cooperatively-running task. The dispatcher
+                    # notifies `signal` off the worker queue; the `finally` notify
+                    # releases the watcher when no interrupt arrives.
+                    signal = Base.Event()
+                    watcher = @async begin
+                        wait(signal)
+                        if !istaskdone(eval_task)
+                            try
+                                schedule(eval_task, InterruptException(); error = true)
+                            catch  # dendro-ignore: empty_catch -- eval finished between the check and the schedule
+                            end
+                        end
+                    end
                     srv.busy_since = Dates.now()
+                    srv.interrupt_signal = signal
                     try
-                        _revise(
-                            _handle_eval,
-                            request.socket,
-                            request.id,
-                            request.code,
-                            srv.mod,
-                            srv.verbose,
-                        )
+                        wait(eval_task)
+                    catch error
+                        # `_handle_eval` reports eval errors to the client itself, so
+                        # a throw here is the eval task failing unexpectedly (e.g. a
+                        # Revise error). Log it and keep the worker alive.
+                        @error "Eval task failed" id = request.id error
                     finally
+                        srv.interrupt_signal = nothing
                         srv.busy_since = nothing
+                        notify(signal)
+                        wait(watcher)
                         # Always decrement counter when done with a connection
                         Threads.atomic_sub!(active_connections, 1)
                     end
@@ -304,6 +346,19 @@ end
 # render it in `ls` to tell a wedged server from an idle one.
 _busy_marker(srv::Server) = isnothing(srv.busy_since) ? "" : string(srv.busy_since)
 
+# Request an interrupt of the running eval, freeing a wedged worker without killing
+# the process. Returns whether an eval was running to interrupt. Called from the
+# dispatcher, off the worker queue, so it reaches a server whose worker is wedged.
+# Notifying the signal wakes the watcher on the eval's thread, which schedules the
+# `InterruptException`. Delivery is cooperative: a tight non-yielding loop never
+# hits a safepoint, so `kill` remains the only recourse there.
+function _interrupt_eval(srv::Server)
+    signal = srv.interrupt_signal
+    isnothing(signal) && return false
+    notify(signal)
+    return true
+end
+
 # Per-connection dispatcher. Reads one frame, answers a ping immediately so
 # liveness never queues behind an evaluation, and hands an eval to the worker.
 # Pings, framing errors, and bare disconnects release the connection here; the
@@ -320,6 +375,10 @@ function _dispatch(
         elseif frame.type == REQUEST_PING
             _write_frame(sock, RESPONSE_PONG, _busy_marker(srv))
             srv.verbose && @info "Answered ping" id
+        elseif frame.type == REQUEST_INTERRUPT
+            delivered = _interrupt_eval(srv)
+            _write_frame(sock, RESPONSE_OK, delivered ? "interrupted" : "no evaluation running")
+            srv.verbose && @info "Answered interrupt" id delivered
         else
             put!(request_queue, ClientRequest(sock, id, frame.body))
             enqueued = true

--- a/test/interrupt_tests.jl
+++ b/test/interrupt_tests.jl
@@ -1,0 +1,88 @@
+@testitem "interrupt_frame_roundtrip" tags = [:protocol, :frame] begin
+    import REPLicant
+
+    buffer = IOBuffer()
+    REPLicant._write_frame(buffer, REPLicant.REQUEST_INTERRUPT, "")
+    seekstart(buffer)
+    frame = REPLicant._read_frame(buffer, REPLicant.REQUEST_TYPES)
+    @test frame.type == REPLicant.REQUEST_INTERRUPT
+    @test frame.body == ""
+    @test REPLicant.REQUEST_INTERRUPT in REPLicant.REQUEST_TYPES
+end
+
+@testitem "interrupt_frees_yielding_eval" tags = [:interrupt] setup = [Utilities] begin
+    import REPLicant
+    import Sockets
+
+    Utilities.withserver() do server, mod, port
+        # Seed session state so a follow-up eval proves the process survived.
+        @test Utilities.request(port, "x = 41") == "41"
+
+        # Wedge the worker on a non-returning but yielding eval. The connection is
+        # held open without reading, so the worker stays busy on it.
+        wedged = Sockets.connect(Sockets.localhost, port)
+        Utilities.sendframe(wedged, "while true; sleep(0.01); end")
+        sleep(0.5)  # let the worker pick it up and record current_eval
+
+        # The interrupt is answered off the worker queue, so it lands even while
+        # the worker is busy.
+        frame = Utilities.requestframe(port, REPLicant.REQUEST_INTERRUPT, "")
+        @test frame.type == REPLicant.RESPONSE_OK
+        @test frame.body == "interrupted"
+
+        # The freed eval reports the interrupt and closes.
+        @test occursin("Interrupt", Utilities.readresp(wedged))
+        close(wedged)
+
+        # A follow-up eval on the same server sees prior state: the session lived.
+        @test Utilities.request(port, "x + 1") == "42"
+    end
+end
+
+@testitem "interrupt_idle_noop" tags = [:interrupt] setup = [Utilities] begin
+    import REPLicant
+
+    Utilities.withserver() do server, mod, port
+        frame = Utilities.requestframe(port, REPLicant.REQUEST_INTERRUPT, "")
+        @test frame.type == REPLicant.RESPONSE_OK
+        @test frame.body == "no evaluation running"
+        # The server keeps evaluating afterward.
+        @test Utilities.request(port, "1 + 1") == "2"
+    end
+end
+
+@testitem "interrupt_cli_resolves_and_replies" tags = [:interrupt, :cli] setup = [Utilities] begin
+    import REPLicant
+
+    Utilities.withserver() do server, mod, port
+        out = IOBuffer()
+        @test REPLicant._interrupt_server(["--port=$port"]; out) == 0
+        @test contains(String(take!(out)), "no evaluation running")
+    end
+end
+
+@testitem "interrupt_does_not_kill_process" tags = [:interrupt, :kill] setup = [Utilities] begin
+    import REPLicant
+    import Sockets
+
+    mktempdir() do work
+        registry = mktempdir()
+        withenv("REPLICANT_DIR" => registry) do
+            Utilities.spawn_server(registry, work) do port, pid
+                # Wedge the worker on a yielding non-returning eval.
+                wedged = Sockets.connect(Sockets.localhost, port)
+                Utilities.sendframe(wedged, "while true; sleep(0.01); end")
+                sleep(0.5)
+
+                out = IOBuffer()
+                @test REPLicant._interrupt_server(["--port=$port"]; out) == 0
+                @test contains(String(take!(out)), "interrupted")
+                close(wedged)
+
+                # The process survived the interrupt, unlike kill.
+                @test REPLicant._process_alive(pid)
+                @test Utilities.request(port, "1 + 2") == "3"
+            end
+        end
+    end
+end

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -18,12 +18,14 @@
         JET_JULIA = v"1.12"
         # The count is intentional dynamic dispatch: eval over `Any`, sound-mode
         # `getfield`/`setfield` on the `cli`/parser NamedTuples and the server's
-        # `busy_since`, and abstract-IO `write`/`show` across the socket paths, the
-        # per-task output `Router`, the `ls` status table, and `_capture`'s pipe
-        # reader. Help mode's `@doc` fallback `show`s a docs object of unknown
-        # type. The `kill` and `--timeout` paths add socket-IO and `println`-over-
-        # `IO` reports in the same category. Threading stays inferrable: opt is 0.
-        SOUND_LIMIT = 316   # JET.report_package(REPLicant; mode = :sound)
+        # `busy_since`/`interrupt_signal`, and abstract-IO `write`/`show` across the
+        # socket paths, the per-task output `Router`, the `ls` status table, and
+        # `_capture`'s pipe reader. Help mode's `@doc` fallback `show`s a docs object
+        # of unknown type. The `kill`, `--timeout`, and `interrupt` paths add
+        # socket-IO and `println`-over-`IO` reports in the same category; running
+        # each eval in its own `@async` task, with a watcher that schedules the
+        # interrupt, adds a few more. Threading stays inferrable: opt is 0.
+        SOUND_LIMIT = 304   # JET.report_package(REPLicant; mode = :sound)
         OPT_LIMIT = 0       # JET.report_opt on _parse_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)


### PR DESCRIPTION
feat(client): add interrupt to free a wedged eval

`kill` is the only recovery for a server wedged on a running eval, and it
destroys the warm session: every variable, every loaded package, the cold
start paid once. `interrupt` is the soft tier. It schedules an
`InterruptException` onto the running eval, freeing it while the process and
its loaded state survive.

The worker runs each eval in its own `@async` task, recorded on the `Server`.
The dispatcher answers `interrupt` off the worker queue, like `ping`, so it
reaches a server whose worker is busy. It notifies a per-eval signal; a watcher
pinned to the eval's thread answers and schedules the exception.

Delivery runs from the eval's own thread for a reason. Scheduling an
`InterruptException` into a task that is running on another thread corrupts the
scheduler and aborts the process. The eval task is sticky (`@async`) and the
watcher shares its thread, so the watcher schedules only while the eval is
parked, the one safe case.

The interrupt reaches the eval inside `include_string`, which wraps it in a
`LoadError`. `_capture` reports it to the client like any error but with no
backtrace: the exception lands at an arbitrary point, and walking that stack
under threads deadlocks in the runtime's stack lookup, leaving the worker
wedged on the eval it just freed.

Delivery is cooperative: a tight non-yielding loop never reaches a safepoint,
so `kill` stays the hard tier.

The client's argument handling takes `Vector{String}` throughout, so JET sound
mode resolves `args[1]` and `args[2:end]` concretely instead of over `Any`.
That collapses the dispatch cascade across `ls`, `kill`, and `interrupt`,
dropping the sound-report ratchet from 316 to 304.

