### PR TITLE
feat(client): run a script file by path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Run a script file with `julia +rpc path/to/script.jl [args...]`: a positional `.jl` argument is forwarded as an absolute path and run with `include`, so the script evaluates in the warm session with the real filename in stack traces, its definitions persisting like any other eval. Trailing positionals become the script's `ARGS` for the run, restored afterward so the session's `ARGS` is unchanged. A script file and `-e`/`--eval` are mutually exclusive [#40]
 - Add `julia +rpc interrupt` to free a server wedged on a running eval without killing it: the request schedules an `InterruptException` onto the running evaluation, answered off the worker queue so it reaches a busy server, leaving the session and its loaded state intact. The worker runs each eval in its own task, so the interrupt frees that eval alone and the server keeps serving. Delivery is cooperative, so a tight non-yielding loop still needs `kill`; `interrupt` is the soft recovery tier [#39]
 - Show evaluation state in `julia +rpc ls`: a `STATUS` column reads `idle`, or `busy <n>s` while the server is mid-evaluation, carried in the pong body so a wedged server is visible without a separate probe [#38]
 - Add `julia +rpc kill [--force]` to terminate a server whose worker is wedged on a non-returning eval. The target resolves from the raw registry (no ping), so a server that cannot answer its socket still resolves; `kill` sends SIGTERM, `--force` sends SIGKILL, the only signal that lands on a tight non-yielding loop. Julia cannot interrupt a running task, so killing the process is the recovery [#38]
@@ -86,3 +87,4 @@ Initial Public Release
 [#36]: https://github.com/MichaelHatherly/REPLicant.jl/issues/36
 [#38]: https://github.com/MichaelHatherly/REPLicant.jl/issues/38
 [#39]: https://github.com/MichaelHatherly/REPLicant.jl/issues/39
+[#40]: https://github.com/MichaelHatherly/REPLicant.jl/issues/40

--- a/src/client.jl
+++ b/src/client.jl
@@ -157,10 +157,14 @@ function _valued_flag(arg)
 end
 
 # Split args into a flag-to-value map and the set of bare flags present, accepting
-# both `--flag value` and `--flag=value`. Unknown arguments error.
+# both `--flag value` and `--flag=value`. A positional `.jl` path is a script to run:
+# it and every following argument (taken verbatim as the script's `ARGS`) end flag
+# parsing, mirroring `julia [opts] script.jl [args]`. Other unknown arguments error.
 function _tokenize_args(args::Vector{String})
     values = Dict{String, String}()
     bare = Set{String}()
+    file = nothing
+    script_args = String[]
     index = 1
     while index <= length(args)
         arg = args[index]
@@ -174,26 +178,36 @@ function _tokenize_args(args::Vector{String})
             end
         elseif arg in BARE_FLAGS
             push!(bare, arg)
+        elseif endswith(arg, ".jl")
+            file = arg
+            script_args = args[(index + 1):end]
+            break
         else
             error("unrecognized argument: $arg")
         end
         index += 1
     end
-    return values, bare
+    return values, bare, file, script_args
 end
 
 # Parse the client's arguments into selectors plus the per-mode flags. One parser
 # serves both paths: eval reads `code`/`timeout`, kill reads `force`. A flag for the
 # other mode is harmless: each caller reads only the fields it acts on.
 function _parse_args(args::Vector{String})
-    values, bare = _tokenize_args(args)
+    values, bare, file, script_args = _tokenize_args(args)
     port = haskey(values, "--port") ? _parse_port(values["--port"]) : -1
     timeout = haskey(values, "--timeout") ? _parse_timeout(values["--timeout"]) : nothing
+    code = get(values, "-e", get(values, "--eval", nothing))
+    isnothing(file) ||
+        isnothing(code) ||
+        error("cannot combine a script file with -e/--eval")
     return (;
         port,
         project = get(values, "--project", ""),
         name = get(values, "--name", ""),
-        code = get(values, "-e", get(values, "--eval", nothing)),
+        code,
+        file,
+        script_args,
         timeout,
         force = !isempty(bare),
     )
@@ -209,6 +223,25 @@ function _parse_timeout(value::AbstractString)
     seconds = tryparse(Float64, value)
     (isnothing(seconds) || seconds <= 0) && error("invalid --timeout: $value")
     return seconds
+end
+
+# Build the code that runs a script file in the warm session. The absolute path is
+# forwarded so the server, sharing the filesystem, reaches the file whatever its
+# cwd, and `include` runs it so stack frames carry the real filename and the
+# script's definitions persist in the session. `ARGS` holds the script's arguments
+# for the run, then is restored from task-local storage so the session's `ARGS` is
+# unchanged afterward and nothing leaks into it.
+function _script_code(file::String, script_args::Vector{String})
+    path = abspath(file)
+    isfile(path) || error("file not found: $file")
+    return """
+    task_local_storage(:replicant_saved_args, copy(ARGS))
+    empty!(ARGS); append!(ARGS, $(repr(script_args)))
+    try
+        include($(repr(path)))
+    finally
+        empty!(ARGS); append!(ARGS, task_local_storage(:replicant_saved_args))
+    end"""
 end
 
 # Write the result, terminating a non-empty payload with a newline so output does
@@ -369,8 +402,9 @@ leading `kill` terminates a resolved server (`--force` for SIGKILL); a leading
 `interrupt` frees a server wedged on a running eval, scheduling an
 `InterruptException` onto it without killing the process (`kill` stays the hard
 tier). Otherwise it resolves a target server and forwards code to it, taken from
-`-e` or, when absent, from stdin. `--timeout <seconds>` bounds the wait for a
-result. Returns a process exit code.
+`-e`, from a leading `script.jl` positional run with `include` (trailing
+positionals become the script's `ARGS`), or, when neither is given, from stdin.
+`--timeout <seconds>` bounds the wait for a result. Returns a process exit code.
 """
 function cli(args::Vector{String} = ARGS; out::IO = stdout, err::IO = stderr)
     try
@@ -385,7 +419,14 @@ function cli(args::Vector{String} = ARGS; out::IO = stdout, err::IO = stderr)
             return _interrupt_server(args[2:end]; out)
         end
         parsed = _parse_args(args)
-        code = isnothing(parsed.code) ? read(stdin, String) : parsed.code
+        file = parsed.file
+        code = if !isnothing(file)
+            _script_code(file, parsed.script_args)
+        elseif isnothing(parsed.code)
+            read(stdin, String)
+        else
+            parsed.code
+        end
         target = _resolve_port(parsed.port, parsed.project, parsed.name)
         return _send(target, code; out, err, timeout_seconds = parsed.timeout)
     catch error

--- a/test/cli_tests.jl
+++ b/test/cli_tests.jl
@@ -224,3 +224,72 @@ end
         end
     end
 end
+
+@testitem "client_script_arg_parsing" tags = [:cli] begin
+    import REPLicant
+
+    bare = REPLicant._parse_args(["script.jl"])
+    @test bare.file == "script.jl"
+    @test bare.script_args == String[]
+    @test isnothing(bare.code)
+
+    withargs = REPLicant._parse_args(["script.jl", "a", "b"])
+    @test withargs.file == "script.jl"
+    @test withargs.script_args == ["a", "b"]
+
+    # Flags before the script are client flags; everything after the script is
+    # passed to it verbatim, even flag-shaped tokens.
+    mixed = REPLicant._parse_args(["--name", "n", "script.jl", "--flag", "x"])
+    @test mixed.name == "n"
+    @test mixed.file == "script.jl"
+    @test mixed.script_args == ["--flag", "x"]
+
+    # A script file and -e/--eval are mutually exclusive.
+    @test_throws Exception REPLicant._parse_args(["-e", "1", "script.jl"])
+
+    # A positional that is not a .jl path is still rejected.
+    @test_throws Exception REPLicant._parse_args(["bogus"])
+end
+
+@testitem "client_runs_script_file" tags = [:cli] setup = [Utilities] begin
+    import REPLicant
+
+    Utilities.withserver() do server, mod, port
+        out = IOBuffer()
+        err = IOBuffer()
+        mktempdir() do dir
+            # ARGS before any script run, to verify the restore afterward.
+            @test REPLicant.cli(["-e", "repr(ARGS)"]; out) == 0
+            before = String(take!(out))
+
+            # A script that prints, reads ARGS, and ends in a value.
+            script = joinpath(dir, "demo.jl")
+            write(script, "println(\"args: \", join(ARGS, \",\"))\n21 * 2")
+            @test REPLicant.cli([script, "X", "Y"]; out) == 0
+            @test String(take!(out)) == "args: X,Y\n42\n"
+
+            # A definition made by the script persists in the session.
+            write(script, "const FROM_SCRIPT = 7")
+            @test REPLicant.cli([script]; out) == 0
+            take!(out)
+            @test REPLicant.cli(["-e", "FROM_SCRIPT"]; out) == 0
+            @test String(take!(out)) == "7\n"
+
+            # ARGS is restored after the run, not left holding the script's args.
+            @test REPLicant.cli(["-e", "repr(ARGS)"]; out) == 0
+            @test String(take!(out)) == before
+
+            # An error in the script names the file, not REPL[N].
+            bad = joinpath(dir, "boom.jl")
+            write(bad, "error(\"kaboom\")")
+            @test REPLicant.cli([bad]; out, err) == 1
+            trace = String(take!(err))
+            @test contains(trace, "kaboom")
+            @test contains(trace, "boom.jl")
+
+            # A missing file is reported, not forwarded.
+            @test REPLicant.cli([joinpath(dir, "nope.jl")]; out, err) == 1
+            @test contains(String(take!(err)), "file not found")
+        end
+    end
+end

--- a/test/test_utilities.jl
+++ b/test/test_utilities.jl
@@ -64,6 +64,11 @@
             read_timeout_seconds::Float64 = 30.0,
         )
         mod = Module()
+        # The running server evaluates in `Main`, which carries the module-local
+        # `include` that `module ... end` syntax injects. A programmatic `Module()`
+        # lacks it, so inject the same definition to run `julia +rpc script.jl` the
+        # way `Main` does.
+        Core.eval(mod, :(include(path) = $(Base.include)($mod, path)))
         mktempdir() do tmp
             registry = mktempdir()
             withenv("REPLICANT_DIR" => registry) do


### PR DESCRIPTION
A positional `.jl` argument runs that file in the warm session. The client
forwards the absolute path and runs it with `include`, so the script
evaluates with the real filename in stack traces and its definitions persist
like any other eval. Trailing positionals become the script's `ARGS` for the
run, restored from task-local storage afterward so the session's `ARGS` is
unchanged. A script file and `-e`/`--eval` are mutually exclusive.
