### PR TITLE
fix: tighten rpc client UX for agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Print usage with `julia +rpc help` (also `--help` and `-h`), listing the subcommands, selectors, and per-mode flags so the surface is discoverable without the skill docs. An unrecognized argument now points at it [#42]
 - Start a server from the client with `julia +rpc start`: it launches a detached process that outlives the client and prints the port once registered, so an agent with no interactive REPL can bring up a warm session. `--dir` roots it at a directory (default the caller's), `--project` picks the environment to activate, `--name` labels it, `--channel` runs a chosen juliaup channel (default the launcher's default version). The server loads `startup.jl` like a normal warm session. Stop it with `julia +rpc kill` [#41]
 - Add named sessions with `--module <name>`: the eval runs in a standalone module instead of the shared default, isolating its state from `Main` and from other named sessions. State persists across calls under the same name, so a distinct name per task keeps `Main` clean [#41]
 - Add `julia +rpc reset --module <name>` to swap a named session for a fresh, empty module, giving a clean slate without restarting the process. The default session is the process's `Main` and cannot be reset, so `--module` is required [#41]
@@ -24,8 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reject `--module Main`: the default session is addressed by omitting `--module`, so a session named `Main` would be a distinct module shadowing that name. Eval and `reset` both error with that guidance instead of handing back a decoy [#42]
 - Run each eval in the caller's working directory: the client sends its directory with the request, so relative paths resolve where `julia +rpc` was invoked rather than where the server started, and a `cd` inside an eval no longer leaks to the next. Override with `--dir <path>` [#41]
-- Warn on stderr when no server owns the caller's directory and a server from another project is used, so a cross-project eval is visible instead of silent. The call still runs [#41]
+- Refuse to evaluate when no server owns the caller's directory and no explicit selector is given, listing the candidates instead of silently running against another project's server. Target a foreign server on purpose with `--port`, `--project`, or `--name` [#41][#42]
 - Carry the working directory and target module in the eval frame, bumping the protocol version to 2. A client and server on mismatched versions read as incompatible and prompt to reinstall the rpc channel [#41]
 - Point the `--timeout` expiry message at `julia +rpc interrupt` as the soft recovery before `kill` [#41]
 - Route evaluation output per task instead of redirecting the process streams: a remote eval captures only its own output while the interactive server's REPL keeps writing to the terminal, so the two no longer steal each other's output [#36]
@@ -34,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Scrub REPLicant's own eval frames from the backtrace of an error raised before any user frame (an undefined top-level binding), which previously dumped the server's internal machinery to the caller. The backtrace now matches the REPL [#42]
+- Report `julia +rpc interrupt` honestly: after scheduling the interrupt, the client confirms the server returned to idle before claiming success, and points at `kill --force` when a non-yielding eval keeps running, instead of always reporting `interrupted` [#42]
+- Give a clear error when `--port` targets a port with no live server, instead of leaking a raw connection-refused `IOError` [#42]
+- Quiet the `Labeled REPLicant server` log unless the server is started verbose [#42]
 - Stop discarding the result of an eval that runs longer than 30 seconds: the client read no longer applies the request timeout to the response, so a long compute returns instead of erroring [#38]
 - Answer liveness pings off the worker queue and time the probe out quickly, so `ls` and server resolution stay responsive while a server is mid-evaluation instead of waiting on the request timeout [#35]
 - Point protocol magic and version mismatch errors at reinstalling the rpc channel, since the usual cause is a client and server on different REPLicant versions [#35]
@@ -96,3 +102,4 @@ Initial Public Release
 [#39]: https://github.com/MichaelHatherly/REPLicant.jl/issues/39
 [#40]: https://github.com/MichaelHatherly/REPLicant.jl/issues/40
 [#41]: https://github.com/MichaelHatherly/REPLicant.jl/issues/41
+[#42]: https://github.com/MichaelHatherly/REPLicant.jl/issues/42

--- a/src/client.jl
+++ b/src/client.jl
@@ -69,9 +69,10 @@ function _candidates_error(candidates::Vector{RegistryEntry}, message::AbstractS
     return ErrorException(String(take!(io)))
 end
 
-# Warn that no server owns the caller's location, so a server rooted at another
-# project was selected. Returns the entry so callers can `return _warn_foreign(...)`.
-# Goes to `err` so it never corrupts a result parsed from stdout.
+# Warn that the server selected by an explicit `--name` is rooted at another
+# project than the caller's location. Returns the entry so callers can
+# `return _warn_foreign(...)`. Goes to `err` so it never corrupts a result parsed
+# from stdout.
 function _warn_foreign(err::IO, entry::RegistryEntry, target::AbstractString)
     println(err, "replicant: no server for $target; falling back to the server in $(entry.project)")
     return entry
@@ -116,11 +117,16 @@ function _select_entry(
         length(named) == 1 && return _warn_foreign(err, named[1], target)
         length(named) > 1 &&
             throw(_candidates_error(named, "multiple servers named \"$name\""))
-    elseif length(candidates) == 1
-        return _warn_foreign(err, candidates[1], target)
     end
 
-    throw(_candidates_error(candidates, "could not pick a server for $target"))
+    # No server owns the caller's location and no explicit selector was given.
+    # Refuse rather than silently evaluating against an unrelated project; an
+    # explicit --port/--project/--name targets a foreign server on purpose.
+    throw(
+        _candidates_error(
+            candidates, "no server owns $target; select one with --port/--project/--name",
+        ),
+    )
 end
 
 # Resolve an eval target to a port: an explicit port wins and connects directly;
@@ -128,7 +134,10 @@ end
 function _resolve_port(
         port::Integer, project::AbstractString, name::AbstractString; err::IO = stderr,
     )
-    port > 0 && return port
+    if port > 0
+        _ping(port) || error("no REPLicant server responding on port $port")
+        return port
+    end
     return _select_entry(_live_entries(), project, name; err).port
 end
 
@@ -198,7 +207,7 @@ function _tokenize_args(args::Vector{String})
             script_args = args[(index + 1):end]
             break
         else
-            error("unrecognized argument: $arg")
+            error("unrecognized argument: $arg; run `julia +rpc help` for usage")
         end
         index += 1
     end
@@ -493,6 +502,10 @@ function _reset_server(args::Vector{String}; out::IO = stdout, err::IO = stderr)
         _write_frame(sock, REQUEST_RESET, parsed.mod)
         frame = _read_frame(sock, RESPONSE_TYPES; timeout_seconds = PING_TIMEOUT_SECONDS)
         isnothing(frame) && error("server closed the connection without a response")
+        if frame.type == RESPONSE_ERR
+            println(err, "replicant: $(frame.body)")
+            return 1
+        end
         println(out, "REPLicant server on port $target: $(frame.body)")
         return 0
     finally
@@ -500,23 +513,52 @@ function _reset_server(args::Vector{String}; out::IO = stdout, err::IO = stderr)
     end
 end
 
+# Poll a server until it reports idle, or the budget elapses. Pings are answered
+# off the worker queue, so a busy worker still pongs (an empty marker means idle).
+# Returns whether the server reached idle.
+function _await_idle(port::Integer; timeout = 2.0)
+    deadline = time() + timeout
+    while time() < deadline
+        _ping_status(port) == "" && return true
+        sleep(0.05)
+    end
+    return false
+end
+
 # Free a server wedged on a running eval without killing the process. Resolves a
 # live server (the soft tier needs a healthy dispatcher to receive the request, so
 # live resolution gives a clean "no servers" error rather than a hang), schedules an
-# `InterruptException` onto the running eval, and reports the outcome.
-function _interrupt_server(args::Vector{String}; out::IO = stdout)
+# `InterruptException` onto the running eval, then confirms it stopped. The signal
+# lands only when the eval yields, so a tight non-yielding loop stays busy: report
+# that and point at `kill --force` rather than claim a success that did not happen.
+function _interrupt_server(args::Vector{String}; out::IO = stdout, err::IO = stderr)
     parsed = _parse_args(args)
     target = _resolve_port(parsed.port, parsed.project, parsed.name)
     sock = Sockets.connect(Sockets.localhost, target)
-    try
+    body = try
         _write_frame(sock, REQUEST_INTERRUPT, "")
         frame = _read_frame(sock, RESPONSE_TYPES; timeout_seconds = PING_TIMEOUT_SECONDS)
         isnothing(frame) && error("server closed the connection without a response")
-        println(out, "REPLicant server on port $target: $(frame.body)")
-        return 0
+        frame.body
     finally
         close(sock)
     end
+
+    if body != "interrupted"
+        # Nothing was running (e.g. "no evaluation running"); report it as-is.
+        println(out, "REPLicant server on port $target: $body")
+        return 0
+    end
+    if _await_idle(target)
+        println(out, "REPLicant server on port $target: interrupted, now idle")
+        return 0
+    end
+    println(
+        err,
+        "replicant: interrupt sent to the server on port $target, but the eval is still \
+        running (not yielding); stop it with: julia +rpc kill --force",
+    )
+    return 1
 end
 
 """
@@ -534,16 +576,51 @@ or, when neither is given, from stdin. The eval runs in the caller's directory
 (override with `--dir`) and in the default session unless `--module <name>` selects
 one. `--timeout <seconds>` bounds the wait for a result. Returns a process exit code.
 """
-# Run a leading subcommand (`ls`/`start`/`kill`/`interrupt`/`reset`) and return its
-# exit code, or `nothing` when `args` does not start with one, so `cli` falls
-# through to evaluation.
+# Usage text for `help`/`--help`/`-h`, listing the subcommands, selectors, and the
+# per-mode flags so an agent can discover the surface without reading the skill.
+const USAGE = """
+julia +rpc — forward Julia code to a warm REPLicant server
+
+Usage:
+  julia +rpc [selectors] -e <code>     evaluate code (also via heredoc/stdin, or a script.jl)
+  julia +rpc ls                        list live servers
+  julia +rpc start [start-options]     start a detached server
+  julia +rpc kill [selectors] [-f]     stop a server (-f/--force sends SIGKILL)
+  julia +rpc interrupt [selectors]     free a server wedged on a running eval
+  julia +rpc reset --module <name>     clear a named session
+  julia +rpc help                      show this message
+
+Selectors:
+  --port <n>         target a specific port
+  --name <label>     target a labeled server
+  --project <path>   select by project root (default: current directory)
+
+Eval options:
+  -e, --eval <code>  code to run (else read stdin, or run a positional script.jl)
+  --dir <path>       working directory for the eval (default: caller's cwd)
+  --module <name>    evaluate into a named session, isolated from the default
+  --timeout <secs>   bound the wait for a result
+
+Start options:
+  --dir <path>       directory to serve (default: current directory)
+  --project <path>   Julia environment to activate (default: the project of --dir)
+  --name <label>     label the server
+  --channel <ver>    juliaup channel to run the server on (default: your default)
+"""
+
+_usage(out::IO) = (print(out, USAGE); 0)
+
+# Run a leading subcommand (`ls`/`start`/`kill`/`interrupt`/`reset`/`help`) and
+# return its exit code, or `nothing` when `args` does not start with one, so `cli`
+# falls through to evaluation.
 function _run_subcommand(args::Vector{String}, out::IO, err::IO)
     isempty(args) && return nothing
     command, rest = args[1], args[2:end]
+    command in ("help", "--help", "-h") && return _usage(out)
     command in ("ls", "list") && return (_list_servers(out); 0)
     command == "start" && return _start_server(rest; out)
     command == "kill" && return _kill_server(rest; out)
-    command == "interrupt" && return _interrupt_server(rest; out)
+    command == "interrupt" && return _interrupt_server(rest; out, err)
     command == "reset" && return _reset_server(rest; out, err)
     return nothing
 end

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -213,12 +213,19 @@ function _new_session(sym::Symbol)
     return mod
 end
 
+# The default session is addressed by omitting `--module`. A named session called
+# "Main" would be a distinct module (`Main.Main`) shadowing that name, so reject it
+# rather than hand back a decoy the caller mistakes for the default.
+_reject_reserved_session(name::AbstractString) =
+    name == "Main" && error("Main is the default session; omit --module to use it")
+
 # The module a request evaluates into: the default session (the server's module, or
 # `Main`) when no `--module` is given, else the named session. Called by the
 # dispatcher when a request is accepted, so the eval's module is fixed before any
 # later reset can swap it.
 function _request_module(srv::Server, name::AbstractString)
     isempty(name) && return @something(srv.mod, Base.active_module())
+    _reject_reserved_session(name)
     return _session_module(srv.sessions, name)
 end
 
@@ -234,6 +241,7 @@ end
 # name is required.
 function _reset_session(srv::Server, name::AbstractString)
     isempty(name) && error("reset needs a module name; the default session cannot be reset")
+    _reject_reserved_session(name)
     Base.@lock srv.sessions.lock srv.sessions.modules[name] = _new_session(Symbol(name))
     return "reset module $name"
 end
@@ -254,12 +262,19 @@ function _show_object(buffer, result, mod)
 end
 
 function _error_message(buffer, result, id)
-    # Clean up the backtrace to match REPL behavior. We truncate at the
-    # first "top-level scope" frame since everything above that is
-    # internal REPLicant machinery that users don't need to see.
+    # Clean up the backtrace to match REPL behavior. Truncate at the first
+    # "top-level scope" frame, since everything below is internal REPLicant
+    # machinery. An error raised while evaluating the top-level expression itself
+    # (an undefined binding) has no such frame, so fall back to the eval entry: cut
+    # just above the first `include_string` frame, which leaves no machinery, as the
+    # REPL shows for that error.
     bt = Base.scrub_repl_backtrace(result.backtrace::Vector)
-    top_level = findfirst(x -> x.func === Symbol("top-level scope"), bt)
-    bt = bt[1:something(top_level, length(bt))]
+    cut = findfirst(x -> x.func === Symbol("top-level scope"), bt)
+    if isnothing(cut)
+        entry = findfirst(x -> x.func === :include_string, bt)
+        cut = isnothing(entry) ? length(bt) : entry - 1
+    end
+    bt = bt[1:cut]
 
     print(buffer, "ERROR: ")
     # invokelatest: a user-defined exception type may have been created during

--- a/src/registry.jl
+++ b/src/registry.jl
@@ -163,6 +163,6 @@ function label!(name::AbstractString)
     )
     _write_registry_entry(port, project; name, started)
     srv.name = name
-    @info "Labeled REPLicant server" port name
+    srv.verbose && @info "Labeled REPLicant server" port name
     return name
 end

--- a/test/cli_tests.jl
+++ b/test/cli_tests.jl
@@ -24,6 +24,50 @@
     @test_throws Exception REPLicant._parse_args(["--bogus"])
 end
 
+@testitem "help_prints_usage" tags = [:cli] begin
+    import REPLicant
+
+    for arg in (["help"], ["--help"], ["-h"])
+        out = IOBuffer()
+        err = IOBuffer()
+        @test REPLicant.cli(arg; out, err) == 0
+        text = String(take!(out))
+        for sub in ("ls", "start", "kill", "interrupt", "reset")
+            @test contains(text, sub)
+        end
+        @test contains(text, "--port")
+        @test contains(text, "--module")
+    end
+end
+
+@testitem "unknown_argument_hints_help" tags = [:cli] begin
+    import REPLicant
+
+    out = IOBuffer()
+    err = IOBuffer()
+    @test REPLicant.cli(["--bogus"]; out, err) == 1
+    @test contains(String(take!(err)), "julia +rpc help")
+end
+
+@testitem "explicit_dead_port_reports_clearly" tags = [:cli] begin
+    import REPLicant
+    import Sockets
+
+    # An OS-assigned port, released at once, so nothing listens there. A direct
+    # `--port` to a dead server must report clearly, not leak a raw socket IOError.
+    probe = Sockets.listen(Sockets.localhost, 0)
+    deadport = Int(Sockets.getsockname(probe)[2])
+    close(probe)
+
+    out = IOBuffer()
+    err = IOBuffer()
+    @test REPLicant.cli(["--port", string(deadport), "-e", "1 + 1"]; out, err) == 1
+    @test contains(
+        String(take!(err)),
+        "no REPLicant server responding on port $deadport",
+    )
+end
+
 @testitem "client_timeout_parsing" tags = [:cli] begin
     import REPLicant
 
@@ -329,31 +373,71 @@ end
     end
 end
 
-@testitem "select_entry_warns_cross_project" tags = [:cli] begin
-    import REPLicant
-
-    # A server rooted at one project, a caller in an unrelated one: the lone server
-    # is still chosen, with a warning that names the foreign project.
-    entries = [REPLicant.RegistryEntry(9001, "/some/project/a", "", "1.12", "111", "t")]
-    err = IOBuffer()
-    chosen = REPLicant._select_entry(entries, "/different/place", ""; err)
-    @test chosen.port == 9001
-    message = String(take!(err))
-    @test contains(message, "no server for")
-    @test contains(message, "/some/project/a")
-end
-
-@testitem "client_cross_project_warns_through_cli" tags = [:cli] setup = [Utilities] begin
+@testitem "rejects_Main_as_session_name" tags = [:cli] setup = [Utilities] begin
     import REPLicant
 
     Utilities.withserver() do server, mod, port
+        # `--module Main` would create a `Main.Main` decoy distinct from the default
+        # session, so eval into it is rejected with exit 1.
         out = IOBuffer()
         err = IOBuffer()
-        # Resolve from a directory the lone server does not own: the eval still runs,
-        # the warning goes to stderr, and stdout carries only the result.
-        @test REPLicant.cli(["--project=/no/such/project", "-e", "6 * 7"]; out, err) == 0
-        @test strip(String(take!(out))) == "42"
-        @test contains(String(take!(err)), "no server for")
+        @test REPLicant.cli(["--port=$port", "--module=Main", "-e", "1 + 1"]; out, err) == 1
+        @test contains(String(take!(err)), "Main is the default session")
+
+        # `reset --module Main` is rejected the same way.
+        out2 = IOBuffer()
+        err2 = IOBuffer()
+        @test REPLicant.cli(["reset", "--port=$port", "--module=Main"]; out = out2, err = err2) == 1
+        @test contains(String(take!(err2)), "Main is the default session")
+
+        # A non-reserved name still isolates state and resets cleanly.
+        @test REPLicant.cli(["--port=$port", "--module=work", "-e", "z = 7"]; out = IOBuffer()) == 0
+        got = IOBuffer()
+        @test REPLicant.cli(["--port=$port", "--module=work", "-e", "z"]; out = got, err = IOBuffer()) == 0
+        @test strip(String(take!(got))) == "7"
+        @test REPLicant.cli(["reset", "--port=$port", "--module=work"]; out = IOBuffer()) == 0
+    end
+end
+
+@testitem "select_entry_refuses_cross_project" tags = [:cli] begin
+    import REPLicant
+
+    # A server rooted at one project, a caller in an unrelated one with no explicit
+    # selector: refuse and list the candidate rather than silently choosing it.
+    entries = [REPLicant.RegistryEntry(9001, "/some/project/a", "", "1.12", "111", "t")]
+    err = IOBuffer()
+    ex = try
+        REPLicant._select_entry(entries, "/different/place", ""; err)
+        nothing
+    catch e
+        e
+    end
+    @test ex isa Exception
+    message = sprint(showerror, ex)
+    @test contains(message, "no server owns")
+    @test contains(message, "9001")
+end
+
+@testitem "client_cross_project_refuses_through_cli" tags = [:cli] setup = [Utilities] begin
+    import REPLicant
+
+    Utilities.withserver() do server, mod, port
+        # From a directory the lone server does not own, with no explicit selector:
+        # refuse, list candidates, and write nothing to stdout.
+        out = IOBuffer()
+        err = IOBuffer()
+        @test REPLicant.cli(["--project=/no/such/project", "-e", "6 * 7"]; out, err) == 1
+        @test isempty(String(take!(out)))
+        message = String(take!(err))
+        @test contains(message, "no server owns")
+        @test contains(message, string(port))
+
+        # An explicit --port targets a foreign server on purpose and still resolves.
+        out2 = IOBuffer()
+        @test REPLicant.cli(
+            ["--project=/no/such/project", "--port=$port", "-e", "6 * 7"]; out = out2,
+        ) == 0
+        @test strip(String(take!(out2))) == "42"
     end
 end
 

--- a/test/error_handling_tests.jl
+++ b/test/error_handling_tests.jl
@@ -89,6 +89,34 @@ end
     @test contains(result.output, "top-level scope")
 end
 
+@testitem "undefined_variable_backtrace_omits_internals" tags = [:error_handling] setup = [Utilities] begin
+    import REPLicant
+    # Drive the real server path: an undefined top-level binding throws before a
+    # `top-level scope` frame exists, so the backtrace must not fall back to dumping
+    # REPLicant's eval machinery to the caller.
+    Utilities.withserver() do server, mod, port
+        body = Utilities.request(port, "undefined_var")
+        @test contains(body, "UndefVarError")
+        for internal in ("_capture", "with_logstate", "evaluation.jl", "_spawn_worker", "server.jl")
+            @test !contains(body, internal)
+        end
+    end
+end
+
+@testitem "ordinary_error_keeps_user_frames" tags = [:error_handling] setup = [Utilities] begin
+    import REPLicant
+    # An error with a user frame still truncates at `top-level scope`, keeping the
+    # user's frames and no eval-entry noise below them.
+    Utilities.withserver() do server, mod, port
+        body = Utilities.request(port, "f(x) = error(\"boom\"); f(1)")
+        @test contains(body, "boom")
+        @test contains(body, "f(")
+        @test contains(body, "top-level scope")
+        @test !contains(body, "_spawn_worker")
+        @test !contains(body, "evaluation.jl")
+    end
+end
+
 @testitem "multiple_errors_in_code" tags = [:error_handling] begin
     mod = Module()
     # Only the first error should be reported

--- a/test/interrupt_tests.jl
+++ b/test/interrupt_tests.jl
@@ -61,6 +61,30 @@ end
     end
 end
 
+@testitem "await_idle_reflects_busy_state" tags = [:interrupt] setup = [Utilities] begin
+    import REPLicant
+
+    # `_interrupt_server` only claims success once the server is idle again. Whether
+    # a scheduled interrupt actually frees a wedged eval is environment-dependent
+    # (thread count, safepoint placement), so test the idle check itself: it must
+    # report not-idle while the worker is busy, which is what turns a stuck eval into
+    # the kill-force message instead of false success.
+    Utilities.withserver() do server, mod, port
+        @test REPLicant._await_idle(port; timeout = 0.5)
+
+        busy = @async Utilities.request(port, "sleep(5)")
+        deadline = time() + 5
+        while isempty(something(REPLicant._ping_status(port), "")) && time() < deadline
+            sleep(0.05)
+        end
+        @test !REPLicant._await_idle(port; timeout = 1.0)
+
+        # `sleep` yields, so the interrupt frees it; drain the held request.
+        @test REPLicant._interrupt_server(["--port=$port"]; out = IOBuffer()) == 0
+        wait(busy)
+    end
+end
+
 @testitem "interrupt_does_not_kill_process" tags = [:interrupt, :kill] setup = [Utilities] begin
     import REPLicant
     import Sockets

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -28,8 +28,11 @@
         # sessions (`Core.eval` building a module under the session lock), and the
         # `reset` and `start` subcommands (subprocess `run`/`Cmd`, the `--channel`
         # launcher, and more keyword-NamedTuple `getfield` over `out`/`err`) account
-        # for the rest. Threading stays inferrable: opt is 0.
-        SOUND_LIMIT = 370   # JET.report_package(REPLicant; mode = :sound)
+        # for the rest. The `help` usage text, the `interrupt` idle-confirmation
+        # poll (`_ping_status` over the socket), and the reserved-session check add
+        # the last few in the same IO/dispatch category. Threading stays inferrable:
+        # opt is 0.
+        SOUND_LIMIT = 379   # JET.report_package(REPLicant; mode = :sound)
         OPT_LIMIT = 0       # JET.report_opt on _parse_args(::Vector{String})
 
         if (VERSION.major, VERSION.minor) == (JET_JULIA.major, JET_JULIA.minor)


### PR DESCRIPTION
Driving REPLicant as the consuming agent surfaced rough edges where the
client reported success it had not achieved, leaked its own internals, or
silently mis-targeted. Each fix makes the surface trustworthy.

- Scrub REPLicant's eval frames from a backtrace raised before any user
  frame (an undefined top-level binding); it now matches the REPL instead
  of dumping `_capture`/`_spawn_worker` and the rest.
- Confirm `interrupt` actually freed the server: poll until idle, and point
  at `kill --force` when a non-yielding eval keeps running, rather than
  always reporting `interrupted`.
- Add `julia +rpc help` (and `--help`/`-h`) listing the subcommands and
  flags; an unrecognized argument points at it.
- Refuse to evaluate when no server owns the caller's directory and no
  explicit selector is given, instead of silently running against another
  project's server.
- Reject `--module Main`, which created a `Main.Main` decoy distinct from
  the default session.
- Report a clear error when `--port` targets a dead port, not a raw
  `IOError`.
- Quiet the `label!` info log unless the server is verbose.
