### PR TITLE
fix(project): root git worktrees at the worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Root a server started in a git worktree at the worktree itself, not the checkout that encloses it. A worktree's `.git` is a file, not a directory, so the old directory-only check walked past it to the enclosing repository: every worktree nested under a checkout (Claude Code's default `.claude/worktrees/<name>`) took on the main project's identity and collided with it in the registry. Servers in separate worktrees now stay isolated [#45]
 - Scrub REPLicant's own eval frames from the backtrace of an error raised before any user frame (an undefined top-level binding), which previously dumped the server's internal machinery to the caller. The backtrace now matches the REPL [#42]
 - Report `julia +rpc interrupt` honestly: after scheduling the interrupt, the client confirms the server returned to idle before claiming success, and points at `kill --force` when a non-yielding eval keeps running, instead of always reporting `interrupted` [#42]
 - Give a clear error when `--port` targets a port with no live server, instead of leaking a raw connection-refused `IOError` [#42]
@@ -105,3 +106,4 @@ Initial Public Release
 [#41]: https://github.com/MichaelHatherly/REPLicant.jl/issues/41
 [#42]: https://github.com/MichaelHatherly/REPLicant.jl/issues/42
 [#44]: https://github.com/MichaelHatherly/REPLicant.jl/issues/44
+[#45]: https://github.com/MichaelHatherly/REPLicant.jl/issues/45

--- a/plugins/replicant/skills/replicant/SKILL.md
+++ b/plugins/replicant/skills/replicant/SKILL.md
@@ -30,3 +30,27 @@ EOF
 - **`references/setup.md`**: when `julia +rpc` is not installed, is not a known
   channel, or cannot reach a server. Install, link the `rpc` channel, wire
   startup.jl, self-test, troubleshoot.
+
+## Strategies
+
+Getting the most from a warm session:
+
+- **Front-load the cost, then iterate.** Load a heavy package or fixture once with
+  `using` or `include`, then keep each eval small. The session holds what you
+  loaded, so the compilation paid on the first call is free on every call after.
+  Re-`using` a package in an eval only when you changed what you import.
+- **Let Revise track your edits.** The recommended startup.jl loads Revise
+  (`setup.md`), so editing a package's source updates the running session in
+  place: change the code, re-run the call, read the new result. Restart only for a
+  change Revise cannot track, such as redefining a `struct`, or a wedged worker.
+- **Explore APIs live instead of guessing.** Evaluate an expression to see its real
+  value and type, and use `?name` or `??name` for docs (`evaluate.md`). A warm
+  session makes this cheap, so confirm a function's behavior rather than assuming
+  it.
+- **Isolate a task in its own module.** `--module <task>` keeps an experiment's
+  bindings out of `Main` and out of other tasks; `reset --module <task>` clears it
+  without restarting (`evaluate.md`). Reach for this when a scratch computation
+  would otherwise clutter the default session.
+- **Use it as a debugging feedback loop.** Define a reproduction once as a
+  function, then vary its inputs across calls without paying startup each time. A
+  fast, deterministic loop is what makes a bug tractable.

--- a/plugins/replicant/skills/replicant/references/servers.md
+++ b/plugins/replicant/skills/replicant/references/servers.md
@@ -58,6 +58,11 @@ A server is pinned to one environment for its life. To work in a different
 environment, `start` another server for it; the selection cascade routes each
 `julia +rpc` call to the server owning its directory.
 
+A git worktree roots as its own project, separate from the main checkout it
+shares files with. A server in the main checkout does not serve its worktrees, so
+`start` one per worktree; the cascade routes each call to its own and keeps their
+sessions isolated. Claude Code's `.claude/worktrees/<name>` worktrees work this way.
+
 ## Reset a session
 
 `julia +rpc reset --module <name>` swaps a named session for a fresh, empty module,

--- a/src/project.jl
+++ b/src/project.jl
@@ -3,12 +3,15 @@
 #
 
 # Root the server at the enclosing git repository, falling back to the working
-# directory. Clients select a server by matching this path (or an ancestor).
+# directory. Clients select a server by matching this path (or an ancestor). A
+# worktree's `.git` is a file (a `gitdir:` pointer), not a directory, so test for
+# the existence of `.git`, not that it is a directory: each worktree then roots at
+# itself rather than climbing to the checkout that encloses it.
 function _project_root(start::AbstractString = pwd())
     start = abspath(start)
     dir = start
     while true
-        isdir(joinpath(dir, ".git")) && return _canonical(dir)
+        ispath(joinpath(dir, ".git")) && return _canonical(dir)
         parent = dirname(dir)
         parent == dir && return _canonical(start)
         dir = parent

--- a/test/cli_tests.jl
+++ b/test/cli_tests.jl
@@ -535,6 +535,24 @@ end
     end
 end
 
+@testitem "client_project_root_worktree" tags = [:cli] begin
+    import REPLicant
+
+    mktempdir() do dir
+        # A main checkout: `.git` is a directory.
+        mkdir(joinpath(dir, ".git"))
+        @test REPLicant._project_root(dir) == REPLicant._canonical(dir)
+
+        # A worktree nested inside the checkout (Claude Code's default
+        # `.claude/worktrees/<name>`): `.git` is a file, not a directory. It must
+        # root at the worktree itself, not climb to the enclosing checkout.
+        worktree = joinpath(dir, ".claude", "worktrees", "feature")
+        mkpath(worktree)
+        write(joinpath(worktree, ".git"), "gitdir: /somewhere/.git/worktrees/feature\n")
+        @test REPLicant._project_root(worktree) == REPLicant._canonical(worktree)
+    end
+end
+
 @testitem "client_check_julia_version" tags = [:cli] begin
     import REPLicant
 


### PR DESCRIPTION
`_project_root` identified a repository by testing for a `.git` directory. In a
git worktree `.git` is a file, so the upward walk climbed past it to the enclosing
checkout. Worktrees nested under a checkout (Claude Code's default
`.claude/worktrees/<name>`) registered the enclosing project's root and collided
with it in the registry, so servers in separate worktrees could not stay isolated.

- Test for `.git` with `ispath` instead of `isdir`, covering the worktree file,
  the main-checkout directory, and a symlink. Each worktree now roots at itself,
  and the deepest-owning cascade routes each worktree's evals to its own server.
- Document it in the `replicant` skill (`servers.md`): a worktree shares the main
  checkout's `Project.toml` but is a separate root that needs its own server.
- Add a `Strategies` section to the skill (`SKILL.md`): front-load expensive
  loads then iterate, let Revise track edits, explore APIs live, isolate a task in
  its own module, and use the session as a debugging feedback loop.